### PR TITLE
feat(procscan): report violations to admin API

### DIFF
--- a/complik/deploy/deploy/charts/procscan/templates/configmap.yaml
+++ b/complik/deploy/deploy/charts/procscan/templates/configmap.yaml
@@ -21,6 +21,10 @@ data:
     notifications:
       lark:
         webhook: {{ .Values.config.notifications.lark.webhook | quote }}
+      admin:
+        base_url: {{ .Values.config.notifications.admin.base_url | quote }}
+        timeout: {{ .Values.config.notifications.admin.timeout | quote }}
+      region: {{ .Values.config.notifications.region | quote }}
 
     detectionRules:
       blacklist:

--- a/complik/deploy/deploy/charts/procscan/values.yaml
+++ b/complik/deploy/deploy/charts/procscan/values.yaml
@@ -65,6 +65,10 @@ config:
   notifications:
     lark:
       webhook: ""
+    admin:
+      base_url: "http://sealos-complik-admin:8080"
+      timeout: "10s"
+    region: "hzh"
 
   detectionRules:
     blacklist:

--- a/complik/pkg/eventbus/eventbus_test.go
+++ b/complik/pkg/eventbus/eventbus_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:testpackage,wsl_v5 // Tests exercise internal event bus state directly.
 package eventbus
 
 import (
@@ -171,7 +172,8 @@ var _ = Describe("EventBus", func() {
 			}()
 
 			received := <-ch
-			receivedPayload := received.Payload.(ComplexPayload)
+			receivedPayload, ok := received.Payload.(ComplexPayload)
+			Expect(ok).To(BeTrue())
 			Expect(receivedPayload.ID).To(Equal(123))
 			Expect(receivedPayload.Name).To(Equal("test"))
 			Expect(receivedPayload.Items).To(Equal([]string{"a", "b", "c"}))
@@ -263,7 +265,8 @@ var _ = Describe("EventBus", func() {
 
 			go func() {
 				for event := range ch {
-					id := event.Payload.(int)
+					id, ok := event.Payload.(int)
+					Expect(ok).To(BeTrue())
 					received[id] = true
 					receivedCount++
 					if receivedCount == 50 {
@@ -311,10 +314,12 @@ var _ = Describe("EventBus", func() {
 				}
 			}()
 
-			received := []int{}
+			received := make([]int, 0, len(events))
 			for range 5 {
 				event := <-ch
-				received = append(received, event.Payload.(int))
+				payload, ok := event.Payload.(int)
+				Expect(ok).To(BeTrue())
+				received = append(received, payload)
 			}
 
 			Expect(received).To(Equal(events))
@@ -330,10 +335,12 @@ var _ = Describe("EventBus", func() {
 			}
 
 			// Should not block or panic
-			received := []int{}
+			received := make([]int, 0, 50)
 			for range 50 {
 				event := <-ch
-				received = append(received, event.Payload.(int))
+				payload, ok := event.Payload.(int)
+				Expect(ok).To(BeTrue())
+				received = append(received, payload)
 			}
 
 			Expect(received).To(HaveLen(50))

--- a/complik/pkg/logger/logger.go
+++ b/complik/pkg/logger/logger.go
@@ -155,6 +155,7 @@ func configureFromEnv() {
 
 	// Log file output
 	if logFile := os.Getenv("COMPLIK_LOG_FILE"); logFile != "" {
+		//nolint:gosec // COMPLIK_LOG_FILE intentionally controls the log output path.
 		file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o666)
 		if err == nil {
 			globalLogger.SetOutput(file)
@@ -358,10 +359,10 @@ func (l *StandardLogger) formatText(level LogLevel, msg string, fields Fields) s
 	levelStr := logLevelNames[level]
 	if l.colored {
 		builder.WriteString(logLevelColors[level])
-		builder.WriteString(fmt.Sprintf("[%-5s]", levelStr))
+		fmt.Fprintf(&builder, "[%-5s]", levelStr)
 		builder.WriteString(resetColor)
 	} else {
-		builder.WriteString(fmt.Sprintf("[%-5s]", levelStr))
+		fmt.Fprintf(&builder, "[%-5s]", levelStr)
 	}
 
 	builder.WriteString(" ")
@@ -392,7 +393,7 @@ func (l *StandardLogger) formatText(level LogLevel, msg string, fields Fields) s
 				builder.WriteString(", ")
 			}
 
-			builder.WriteString(fmt.Sprintf("%s=%v", k, v))
+			fmt.Fprintf(&builder, "%s=%v", k, v)
 
 			first = false
 		}

--- a/complik/pkg/logger/metrics.go
+++ b/complik/pkg/logger/metrics.go
@@ -142,7 +142,6 @@ func (mc *MetricsCollector) updateSystemMetrics() {
 		mc.metrics.GCPauseTime = time.Duration(m.PauseTotalNs)
 	}
 
-	mc.metrics.GCPauseTime = time.Duration(m.PauseTotalNs)
 	mc.metrics.Uptime = time.Since(mc.metrics.StartTime)
 }
 
@@ -193,5 +192,3 @@ func (mc *MetricsCollector) logMetrics() {
 		})
 	}
 }
-
-var globalMetrics *MetricsCollector

--- a/complik/pkg/logger/rotation.go
+++ b/complik/pkg/logger/rotation.go
@@ -186,18 +186,6 @@ func (w *RotatingFileWriter) cleanupBackups() {
 	}
 }
 
-// cleanupOldFiles periodically cleans up old log files
-func (w *RotatingFileWriter) cleanupOldFiles() {
-	ticker := time.NewTicker(24 * time.Hour)
-	defer ticker.Stop()
-
-	for range ticker.C {
-		w.mu.Lock()
-		w.cleanupBackups()
-		w.mu.Unlock()
-	}
-}
-
 // MultiWriter writes to multiple output destinations simultaneously
 type MultiWriter struct {
 	writers []io.Writer

--- a/complik/pkg/plugin/manager.go
+++ b/complik/pkg/plugin/manager.go
@@ -152,27 +152,19 @@ func (m *Manager) StartAllWithTimeout() error {
 		}(name, instance)
 	}
 
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
+	wg.Wait()
+	close(errChan)
 
-	select {
-	case <-done:
-		close(errChan)
-
-		var errors []error
-		for err := range errChan {
-			errors = append(errors, err)
-		}
-
-		if len(errors) > 0 {
-			return fmt.Errorf("failed to start %d plugins: %v", len(errors), errors)
-		}
-
-		return nil
+	var errors []error
+	for err := range errChan {
+		errors = append(errors, err)
 	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to start %d plugins: %v", len(errors), errors)
+	}
+
+	return nil
 }
 
 func (m *Manager) StopAll() error {

--- a/complik/pkg/plugin/manager_test.go
+++ b/complik/pkg/plugin/manager_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:testpackage,wsl_v5 // Tests exercise internal plugin manager state directly.
 package plugin
 
 import (
@@ -298,7 +299,7 @@ var _ = Describe("PluginManager", func() {
 				{Name: "plugin2", Type: "compliance", Enabled: true},
 			}
 
-			manager.LoadPlugins(configs)
+			Expect(manager.LoadPlugins(configs)).To(Succeed())
 			err := manager.StartAll()
 
 			Expect(err).To(HaveOccurred())
@@ -319,7 +320,7 @@ var _ = Describe("PluginManager", func() {
 				{Name: "plugin2", Type: "compliance", Enabled: true},
 			}
 
-			manager.LoadPlugins(configs)
+			Expect(manager.LoadPlugins(configs)).To(Succeed())
 
 			start := time.Now()
 			err := manager.StartAll()
@@ -344,8 +345,8 @@ var _ = Describe("PluginManager", func() {
 				{Name: "plugin2", Type: "compliance", Enabled: true},
 			}
 
-			manager.LoadPlugins(configs)
-			manager.StartAll()
+			Expect(manager.LoadPlugins(configs)).To(Succeed())
+			Expect(manager.StartAll()).To(Succeed())
 
 			err := manager.StopAll()
 			Expect(err).NotTo(HaveOccurred())
@@ -367,8 +368,8 @@ var _ = Describe("PluginManager", func() {
 				{Name: "plugin2", Type: "compliance", Enabled: true},
 			}
 
-			manager.LoadPlugins(configs)
-			manager.StartAll()
+			Expect(manager.LoadPlugins(configs)).To(Succeed())
+			Expect(manager.StartAll()).To(Succeed())
 
 			err := manager.StopAll()
 			Expect(err).NotTo(HaveOccurred()) // Should not propagate errors
@@ -401,7 +402,7 @@ var _ = Describe("PluginManager", func() {
 						Type:    "test",
 						Enabled: true,
 					}
-					manager.LoadPlugin(cfg)
+					Expect(manager.LoadPlugin(cfg)).To(Succeed())
 				}(i)
 			}
 

--- a/complik/plugins/compliance/collector/browser/collector.go
+++ b/complik/plugins/compliance/collector/browser/collector.go
@@ -18,6 +18,7 @@
 package browser
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -28,8 +29,11 @@ import (
 	"github.com/bearslyricattack/CompliK/complik/plugins/compliance/collector/browser/utils"
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
-	"golang.org/x/net/context"
 )
+
+type contextKey string
+
+const startTimeContextKey contextKey = "start_time"
 
 type CollectorInfo struct {
 	DiscoveryName string `json:"discovery_name"`
@@ -184,7 +188,7 @@ func (s *Collector) CollectorAndScreenshot(
 		return nil, err
 	}
 
-	if startTime, ok := taskCtx.Value("start_time").(time.Time); ok {
+	if startTime, ok := taskCtx.Value(startTimeContextKey).(time.Time); ok {
 		duration = time.Duration(time.Since(startTime).Milliseconds())
 	} else {
 		duration = 0

--- a/complik/plugins/compliance/collector/browser/plugin.go
+++ b/complik/plugins/compliance/collector/browser/plugin.go
@@ -172,7 +172,7 @@ func (p *BrowserPlugin) Start(
 					ctx,
 					time.Duration(p.browserConfig.CollectorTimeoutSecond)*time.Second,
 				)
-				taskCtx = context.WithValue(taskCtx, "start_time", time.Now())
+				taskCtx = context.WithValue(taskCtx, startTimeContextKey, time.Now())
 
 				defer cancel()
 

--- a/complik/plugins/compliance/detector/utils/reviewer.go
+++ b/complik/plugins/compliance/detector/utils/reviewer.go
@@ -70,15 +70,7 @@ func (r *ContentReviewer) ReviewSiteContent(
 		"has_custom_rules": len(customRules) > 0,
 	})
 
-	requestData, err := r.prepareRequestData(content, customRules)
-	if err != nil {
-		r.log.Error("Failed to prepare request data", logger.Fields{
-			"error": err.Error(),
-			"host":  content.Host,
-		})
-
-		return nil, fmt.Errorf("failed to prepare request data: %w", err)
-	}
+	requestData := r.prepareRequestData(content, customRules)
 
 	r.log.Debug("Calling review API", logger.Fields{
 		"api_url": r.apiURL,
@@ -119,7 +111,7 @@ func (r *ContentReviewer) ReviewSiteContent(
 func (r *ContentReviewer) prepareRequestData(
 	content *models.CollectorInfo,
 	customRules []CustomKeywordRule,
-) (map[string]any, error) {
+) map[string]any {
 	base64Image := base64.StdEncoding.EncodeToString(content.Screenshot)
 	htmlContent := content.HTML
 
@@ -134,7 +126,7 @@ func (r *ContentReviewer) prepareRequestData(
 	}
 
 	var prompt string
-	if customRules == nil || len(customRules) == 0 {
+	if len(customRules) == 0 {
 		prompt = r.buildPrompt(htmlContent)
 	} else {
 		prompt = r.buildCustomPrompt(htmlContent, customRules)
@@ -163,7 +155,7 @@ func (r *ContentReviewer) prepareRequestData(
 		"response_format":       ReviewResultSchema,
 	}
 
-	return requestData, nil
+	return requestData
 }
 
 func (r *ContentReviewer) buildPrompt(htmlContent string) string {

--- a/complik/plugins/compliance/path/higress/plugin.go
+++ b/complik/plugins/compliance/path/higress/plugin.go
@@ -287,18 +287,18 @@ func (p *HigressPlugin) buildQuery(ingress models.DiscoveryInfo) string {
 	var builder strings.Builder
 
 	// Base query: filter by namespace and keywords
-	builder.WriteString(fmt.Sprintf(`{namespace="%s"} `, ingress.Namespace))
+	fmt.Fprintf(&builder, `{namespace="%s"} `, ingress.Namespace)
 
 	// Add path keyword search
 	if ingress.Host != "" {
-		builder.WriteString(fmt.Sprintf(`"%s" `, ingress.Host))
+		fmt.Fprintf(&builder, `"%s" `, ingress.Host)
 	}
 
 	// Add time range
-	builder.WriteString(fmt.Sprintf(`_time:%s `, p.config.TimeRange))
+	fmt.Fprintf(&builder, `_time:%s `, p.config.TimeRange)
 
 	// Add application filter
-	builder.WriteString(fmt.Sprintf(`app:="%s" `, p.config.App))
+	fmt.Fprintf(&builder, `app:="%s" `, p.config.App)
 
 	// Add JSON parsing and field extraction
 	builder.WriteString(`| unpack_json `)
@@ -339,7 +339,7 @@ func (p *HigressPlugin) sendLogQuery(query string) (*http.Response, error) {
 			"statusCode": resp.StatusCode,
 			"status":     resp.Status,
 		})
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		return nil, fmt.Errorf("response error, status code: %d", resp.StatusCode)
 	}
@@ -361,7 +361,7 @@ func (p *HigressPlugin) generateRequest(query string) (*http.Request, error) {
 		"url": baseURL,
 	})
 
-	req, err := http.NewRequest(http.MethodGet, baseURL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL, nil)
 	if err != nil {
 		p.log.Error("Failed to create HTTP request", logger.Fields{
 			"url":   baseURL,

--- a/complik/plugins/discovery/cronjob/complete/plugin.go
+++ b/complik/plugins/discovery/cronjob/complete/plugin.go
@@ -156,8 +156,8 @@ func (p *CompletePlugin) Start(
 			"startDelay": p.completeConfig.StartTimeSecond,
 		})
 		time.Sleep(time.Duration(p.completeConfig.StartTimeSecond) * time.Second)
-		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
-		p.executeTask(ctx, eventBus)
+		taskCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+		p.executeTask(taskCtx, eventBus)
 		cancel()
 	} else {
 		p.log.Debug("Auto-start disabled, waiting for scheduled intervals")
@@ -177,8 +177,8 @@ func (p *CompletePlugin) Start(
 			case <-ticker.C:
 				p.log.Debug("Scheduled task trigger")
 
-				ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
-				p.executeTask(ctx, eventBus)
+				taskCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+				p.executeTask(taskCtx, eventBus)
 				cancel()
 			case <-ctx.Done():
 				p.log.Info("Context cancelled, stopping Complete plugin scheduler")

--- a/complik/plugins/discovery/cronjob/devbox/plugin.go
+++ b/complik/plugins/discovery/cronjob/devbox/plugin.go
@@ -178,7 +178,7 @@ func (p *DevboxPlugin) Start(
 			case <-ticker.C:
 				p.log.Debug("Scheduled task trigger")
 
-				taskCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				taskCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 				p.executeTask(taskCtx, eventBus)
 				cancel()
 			case <-ctx.Done():

--- a/complik/plugins/handle/lark/notifier.go
+++ b/complik/plugins/handle/lark/notifier.go
@@ -15,10 +15,13 @@
 // Package lark implements notification functionality for Lark (Feishu) messaging.
 // This file contains the notifier implementation that sends formatted messages
 // to Lark webhooks with support for whitelist filtering and rich card formatting.
+//
+//nolint:wsl_v5 // Card construction keeps related branches compact.
 package lark
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -157,9 +160,9 @@ func (f *Notifier) buildWhitelistMessage(
 		pathContent.WriteString("**Detection Paths:**\n")
 		for i, path := range results.Path {
 			if i < 5 {
-				pathContent.WriteString(fmt.Sprintf("  • %s\n", path))
+				fmt.Fprintf(&pathContent, "  • %s\n", path)
 			} else if i == 5 {
-				pathContent.WriteString(fmt.Sprintf("  • ... %d more paths\n", len(results.Path)-5))
+				fmt.Fprintf(&pathContent, "  • ... %d more paths\n", len(results.Path)-5)
 				break
 			}
 		}
@@ -299,7 +302,7 @@ func (f *Notifier) buildWhitelistMessage(
 				keywordContent.WriteString(", ")
 			}
 
-			keywordContent.WriteString(fmt.Sprintf("`%s`", keyword))
+			fmt.Fprintf(&keywordContent, "`%s`", keyword)
 		}
 
 		detectionElements = append(detectionElements, map[string]any{
@@ -321,8 +324,13 @@ func (f *Notifier) buildWhitelistMessage(
 		})
 	}
 
-	elements := append(basicInfoElements, whitelistElements...)
-
+	elements := make(
+		[]map[string]any,
+		0,
+		len(basicInfoElements)+len(whitelistElements)+len(detectionElements)+2,
+	)
+	elements = append(elements, basicInfoElements...)
+	elements = append(elements, whitelistElements...)
 	elements = append(elements, detectionElements...)
 
 	elements = append(elements,
@@ -404,9 +412,9 @@ func (f *Notifier) buildAlertMessage(results *models.DetectorInfo) map[string]an
 		pathContent.WriteString("**Detection Paths:**\n")
 		for i, path := range results.Path {
 			if i < 5 {
-				pathContent.WriteString(fmt.Sprintf("  • %s\n", path))
+				fmt.Fprintf(&pathContent, "  • %s\n", path)
 			} else if i == 5 {
-				pathContent.WriteString(fmt.Sprintf("  • ... %d more paths\n", len(results.Path)-5))
+				fmt.Fprintf(&pathContent, "  • ... %d more paths\n", len(results.Path)-5)
 				break
 			}
 		}
@@ -423,8 +431,7 @@ func (f *Notifier) buildAlertMessage(results *models.DetectorInfo) map[string]an
 	basicInfoElements = append(basicInfoElements, map[string]any{
 		"tag": "hr",
 	})
-	//nolint:gocritic
-	elements := append(basicInfoElements)
+	elements := basicInfoElements
 	if results.IsIllegal {
 		elements = append(elements, map[string]any{
 			"tag": "hr",
@@ -458,7 +465,7 @@ func (f *Notifier) buildAlertMessage(results *models.DetectorInfo) map[string]an
 					keywordContent.WriteString(", ")
 				}
 
-				keywordContent.WriteString(fmt.Sprintf("`%s`", keyword))
+				fmt.Fprintf(&keywordContent, "`%s`", keyword)
 			}
 
 			violationElements = append(violationElements, map[string]any{
@@ -537,15 +544,24 @@ func (f *Notifier) sendMessage(message LarkMessage) error {
 		return fmt.Errorf("failed to serialize message: %w", err)
 	}
 
-	resp, err := f.HTTPClient.Post(
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
 		f.WebhookURL,
-		"application/json",
 		bytes.NewBuffer(jsonData),
 	)
 	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := f.HTTPClient.Do(req)
+	if err != nil {
 		return fmt.Errorf("failed to send HTTP request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -559,7 +575,7 @@ func (f *Notifier) sendMessage(message LarkMessage) error {
 
 	if resp.StatusCode != http.StatusOK || larkResp.Code != 0 {
 		return fmt.Errorf(
-			"Lark webhook notification failed: HTTP status %d, Lark error code %d, error message: %s",
+			"lark webhook notification failed: HTTP status %d, Lark error code %d, error message: %s",
 			resp.StatusCode,
 			larkResp.Code,
 			larkResp.Msg,

--- a/procscan/config.yaml
+++ b/procscan/config.yaml
@@ -46,6 +46,10 @@ notifications:
     timeout: "30s"
     # Retry count on send failure (recommended: 1-3 times)
     retry_count: 3
+  # Admin API configuration
+  admin:
+    base_url: "http://sealos-complik-admin:8080"
+    timeout: "10s"
   # Region configuration
   region: "hzh"
 

--- a/procscan/deploy/manifests/configmap.yaml
+++ b/procscan/deploy/manifests/configmap.yaml
@@ -22,6 +22,9 @@ data:
         webhook: ""
         timeout: "30s"
         retry_count: 3
+      admin:
+        base_url: "http://sealos-complik-admin:8080"
+        timeout: "10s"
 
     metrics:
       enabled: false

--- a/procscan/internal/core/processor/process.go
+++ b/procscan/internal/core/processor/process.go
@@ -115,8 +115,8 @@ func matchAny(text string, regexps []*regexp.Regexp) (bool, string) {
 	return false, ""
 }
 
-// AnalyzeProcess analyzes a single process to determine if it's malicious
-// Returns process info if malicious, nil otherwise
+// AnalyzeProcess returns a process sample for blacklist hits. Whitelist matches
+// are marked as non-illegal so admin can keep the detection record.
 // This function queries container info on-demand instead of using cache
 func (p *Processor) AnalyzeProcess(pid int) (*models.ProcessInfo, error) {
 	procDir := filepath.Join(p.ProcPath, strconv.Itoa(pid))
@@ -149,13 +149,7 @@ func (p *Processor) AnalyzeProcess(pid int) (*models.ProcessInfo, error) {
 	}
 	procLogger.WithField("reason", message).Info("Process matched blacklist rule")
 
-	// Step 2: Check process whitelist (before heavy operations)
-	if p.isProcessWhitelisted(processName, cmdline) {
-		procLogger.Info("Process is whitelisted, ignoring")
-		return nil, nil
-	}
-
-	// Step 3: Identify container main process
+	// Step 2: Identify container main process
 	mainProcessPID := pid
 	processStatus, err := ReadProcessStatus(p.ProcPath, pid)
 	if err != nil {
@@ -178,10 +172,10 @@ func (p *Processor) AnalyzeProcess(pid int) (*models.ProcessInfo, error) {
 		}
 	}
 
-	// Step 4: Get container ID
+	// Step 3: Get container ID
 	containerID := p.getContainerIDFromPID(mainProcessPID)
 
-	// Step 5: Query container info on-demand when container metadata is available.
+	// Step 4: Query container info on-demand when container metadata is available.
 	var podName, namespace string
 	if containerID == "" {
 		procLogger.Debug("Unable to determine container ID, continue alerting without container metadata")
@@ -197,47 +191,43 @@ func (p *Processor) AnalyzeProcess(pid int) (*models.ProcessInfo, error) {
 		}
 	}
 
-	// Step 6: Check infrastructure whitelist
-	if (namespace != "" || podName != "") && p.isInfraWhitelisted(namespace, podName) {
-		procLogger.WithFields(logrus.Fields{
-			"namespace": namespace,
-			"pod":       podName,
-		}).Info("Infrastructure (namespace/pod) is whitelisted, ignoring")
-		return nil, nil
-	}
-
-	displayContainerID := containerID
-	if displayContainerID == "" {
-		displayContainerID = "unknown"
-	}
-	displayPodName := podName
-	if displayPodName == "" {
-		displayPodName = "unknown"
-	}
-	displayNamespace := namespace
-	if displayNamespace == "" {
-		displayNamespace = "unknown"
-	}
-
-	// Step 7: Confirmed as suspicious process
-	procLogger.WithFields(logrus.Fields{
-		"namespace":        displayNamespace,
-		"pod":              displayPodName,
-		"containerID":      displayContainerID,
-		"malicious_pid":    pid,
-		"main_process_pid": mainProcessPID,
-	}).Warn("Confirmed malicious process detected")
-
-	return &models.ProcessInfo{
+	processInfo := &models.ProcessInfo{
 		PID:         pid,
 		ProcessName: processName,
 		Command:     cmdline,
 		Timestamp:   time.Now().Format(time.RFC3339),
-		ContainerID: displayContainerID,
+		ContainerID: displayValueOrUnknown(containerID),
 		Message:     message,
-		PodName:     displayPodName,
-		Namespace:   displayNamespace,
-	}, nil
+		PodName:     displayValueOrUnknown(podName),
+		Namespace:   displayValueOrUnknown(namespace),
+		IsIllegal:   true,
+	}
+
+	// Step 5: Mark whitelist matches as legal samples.
+	if p.isProcessWhitelisted(processName, cmdline) {
+		procLogger.Info("Process matched whitelist")
+		processInfo.IsIllegal = false
+		return processInfo, nil
+	}
+	if (namespace != "" || podName != "") && p.isInfraWhitelisted(namespace, podName) {
+		procLogger.WithFields(logrus.Fields{
+			"namespace": namespace,
+			"pod":       podName,
+		}).Info("Infrastructure matched whitelist")
+		processInfo.IsIllegal = false
+		return processInfo, nil
+	}
+
+	// Step 6: Confirmed as suspicious process
+	procLogger.WithFields(logrus.Fields{
+		"namespace":        processInfo.Namespace,
+		"pod":              processInfo.PodName,
+		"containerID":      processInfo.ContainerID,
+		"malicious_pid":    pid,
+		"main_process_pid": mainProcessPID,
+	}).Warn("Confirmed malicious process detected")
+
+	return processInfo, nil
 }
 
 // isBlacklisted checks if a process name or command line matches blacklist rules
@@ -319,4 +309,11 @@ func isHexString(s string) bool {
 		}
 	}
 	return true
+}
+
+func displayValueOrUnknown(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "unknown"
+	}
+	return value
 }

--- a/procscan/internal/core/processor/process.go
+++ b/procscan/internal/core/processor/process.go
@@ -115,8 +115,7 @@ func matchAny(text string, regexps []*regexp.Regexp) (bool, string) {
 	return false, ""
 }
 
-// AnalyzeProcess returns a process sample for blacklist hits. Whitelist matches
-// are marked as non-illegal so admin can keep the detection record.
+// AnalyzeProcess returns process info for blacklist hits after whitelist checks.
 // This function queries container info on-demand instead of using cache
 func (p *Processor) AnalyzeProcess(pid int) (*models.ProcessInfo, error) {
 	procDir := filepath.Join(p.ProcPath, strconv.Itoa(pid))
@@ -149,7 +148,13 @@ func (p *Processor) AnalyzeProcess(pid int) (*models.ProcessInfo, error) {
 	}
 	procLogger.WithField("reason", message).Info("Process matched blacklist rule")
 
-	// Step 2: Identify container main process
+	// Step 2: Check process whitelist
+	if p.isProcessWhitelisted(processName, cmdline) {
+		procLogger.Info("Process matched whitelist")
+		return nil, nil
+	}
+
+	// Step 3: Identify container main process
 	mainProcessPID := pid
 	processStatus, err := ReadProcessStatus(p.ProcPath, pid)
 	if err != nil {
@@ -172,10 +177,10 @@ func (p *Processor) AnalyzeProcess(pid int) (*models.ProcessInfo, error) {
 		}
 	}
 
-	// Step 3: Get container ID
+	// Step 4: Get container ID
 	containerID := p.getContainerIDFromPID(mainProcessPID)
 
-	// Step 4: Query container info on-demand when container metadata is available.
+	// Step 5: Query container info on-demand when container metadata is available.
 	var podName, namespace string
 	if containerID == "" {
 		procLogger.Debug("Unable to determine container ID, continue alerting without container metadata")
@@ -191,6 +196,15 @@ func (p *Processor) AnalyzeProcess(pid int) (*models.ProcessInfo, error) {
 		}
 	}
 
+	// Step 6: Check infrastructure whitelist
+	if (namespace != "" || podName != "") && p.isInfraWhitelisted(namespace, podName) {
+		procLogger.WithFields(logrus.Fields{
+			"namespace": namespace,
+			"pod":       podName,
+		}).Info("Infrastructure matched whitelist")
+		return nil, nil
+	}
+
 	processInfo := &models.ProcessInfo{
 		PID:         pid,
 		ProcessName: processName,
@@ -203,22 +217,7 @@ func (p *Processor) AnalyzeProcess(pid int) (*models.ProcessInfo, error) {
 		IsIllegal:   true,
 	}
 
-	// Step 5: Mark whitelist matches as legal samples.
-	if p.isProcessWhitelisted(processName, cmdline) {
-		procLogger.Info("Process matched whitelist")
-		processInfo.IsIllegal = false
-		return processInfo, nil
-	}
-	if (namespace != "" || podName != "") && p.isInfraWhitelisted(namespace, podName) {
-		procLogger.WithFields(logrus.Fields{
-			"namespace": namespace,
-			"pod":       podName,
-		}).Info("Infrastructure matched whitelist")
-		processInfo.IsIllegal = false
-		return processInfo, nil
-	}
-
-	// Step 6: Confirmed as suspicious process
+	// Step 7: Confirmed as suspicious process
 	procLogger.WithFields(logrus.Fields{
 		"namespace":        processInfo.Namespace,
 		"pod":              processInfo.PodName,

--- a/procscan/internal/core/scanner/admin_reporter.go
+++ b/procscan/internal/core/scanner/admin_reporter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -15,7 +16,6 @@ import (
 )
 
 const (
-	defaultAdminBaseURL = "http://sealos-complik-admin:8080"
 	defaultAdminTimeout = 10 * time.Second
 	adminViolationsPath = "/api/procscan-violations"
 )
@@ -37,11 +37,17 @@ type procscanViolationRequest struct {
 }
 
 func (s *Scanner) reportProcscanViolations(processInfos []*models.ProcessInfo) {
+	endpoint, ok := s.adminEndpoint()
+	if !ok {
+		legacy.L.Info("Admin reporting is disabled because notifications.admin.base_url is empty")
+		return
+	}
+
 	for _, processInfo := range processInfos {
 		if processInfo == nil {
 			continue
 		}
-		if err := s.reportProcscanViolation(processInfo); err != nil {
+		if err := s.reportProcscanViolation(endpoint, processInfo); err != nil {
 			legacy.L.WithFields(map[string]any{
 				"namespace": processInfo.Namespace,
 				"pod":       processInfo.PodName,
@@ -52,7 +58,7 @@ func (s *Scanner) reportProcscanViolations(processInfos []*models.ProcessInfo) {
 	}
 }
 
-func (s *Scanner) reportProcscanViolation(processInfo *models.ProcessInfo) error {
+func (s *Scanner) reportProcscanViolation(endpoint string, processInfo *models.ProcessInfo) error {
 	if strings.TrimSpace(processInfo.Namespace) == "" {
 		return fmt.Errorf("namespace is required")
 	}
@@ -85,18 +91,18 @@ func (s *Scanner) reportProcscanViolation(processInfo *models.ProcessInfo) error
 	ctx, cancel := context.WithTimeout(context.Background(), s.adminTimeout())
 	defer cancel()
 
-	return postJSON(ctx, s.adminEndpoint(), payload)
+	return postJSON(ctx, endpoint, payload)
 }
 
-func (s *Scanner) adminEndpoint() string {
+func (s *Scanner) adminEndpoint() (string, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	baseURL := strings.TrimSpace(s.config.Notifications.Admin.BaseURL)
 	if baseURL == "" {
-		baseURL = defaultAdminBaseURL
+		return "", false
 	}
-	return strings.TrimRight(baseURL, "/") + adminViolationsPath
+	return strings.TrimRight(baseURL, "/") + adminViolationsPath, true
 }
 
 func (s *Scanner) adminTimeout() time.Duration {
@@ -129,8 +135,17 @@ func postJSON(ctx context.Context, endpoint string, payload any) error {
 		_ = resp.Body.Close()
 	}()
 
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+		bodyText := strings.TrimSpace(string(responseBody))
+		if bodyText != "" {
+			return fmt.Errorf("unexpected status %s: %s", resp.Status, bodyText)
+		}
+		return fmt.Errorf("unexpected status %s", resp.Status)
 	}
 	return nil
 }

--- a/procscan/internal/core/scanner/admin_reporter.go
+++ b/procscan/internal/core/scanner/admin_reporter.go
@@ -125,7 +125,9 @@ func postJSON(ctx context.Context, endpoint string, payload any) error {
 	if err != nil {
 		return fmt.Errorf("send request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return fmt.Errorf("unexpected status code %d", resp.StatusCode)

--- a/procscan/internal/core/scanner/admin_reporter.go
+++ b/procscan/internal/core/scanner/admin_reporter.go
@@ -1,0 +1,156 @@
+package scanner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	legacy "github.com/bearslyricattack/CompliK/procscan/pkg/logger/legacy"
+	"github.com/bearslyricattack/CompliK/procscan/pkg/models"
+)
+
+const (
+	defaultAdminBaseURL = "http://sealos-complik-admin:8080"
+	defaultAdminTimeout = 10 * time.Second
+	adminViolationsPath = "/api/procscan-violations"
+)
+
+type procscanViolationRequest struct {
+	Namespace      string    `json:"namespace"`
+	PodName        string    `json:"pod_name,omitempty"`
+	ContainerID    string    `json:"container_id,omitempty"`
+	NodeName       string    `json:"node_name,omitempty"`
+	PID            int       `json:"pid"`
+	ProcessName    string    `json:"process_name"`
+	ProcessCommand string    `json:"process_command"`
+	MatchType      string    `json:"match_type,omitempty"`
+	MatchRule      string    `json:"match_rule,omitempty"`
+	Message        string    `json:"message"`
+	IsIllegal      bool      `json:"is_illegal"`
+	DetectedAt     time.Time `json:"detected_at"`
+	RawPayload     any       `json:"raw_payload,omitempty"`
+}
+
+func (s *Scanner) reportProcscanViolations(processInfos []*models.ProcessInfo) {
+	for _, processInfo := range processInfos {
+		if processInfo == nil {
+			continue
+		}
+		if err := s.reportProcscanViolation(processInfo); err != nil {
+			legacy.L.WithFields(map[string]any{
+				"namespace": processInfo.Namespace,
+				"pod":       processInfo.PodName,
+				"pid":       processInfo.PID,
+				"error":     err.Error(),
+			}).Error("Failed to report procscan violation to admin")
+		}
+	}
+}
+
+func (s *Scanner) reportProcscanViolation(processInfo *models.ProcessInfo) error {
+	if strings.TrimSpace(processInfo.Namespace) == "" {
+		return fmt.Errorf("namespace is required")
+	}
+
+	matchType, matchRule := parseMatchDetails(processInfo.Message)
+	detectedAt, err := time.Parse(time.RFC3339, processInfo.Timestamp)
+	if err != nil {
+		detectedAt = time.Now().UTC()
+	}
+
+	payload := procscanViolationRequest{
+		Namespace:      processInfo.Namespace,
+		PodName:        processInfo.PodName,
+		ContainerID:    processInfo.ContainerID,
+		NodeName:       currentNodeName(),
+		PID:            processInfo.PID,
+		ProcessName:    processInfo.ProcessName,
+		ProcessCommand: processInfo.Command,
+		MatchType:      matchType,
+		MatchRule:      matchRule,
+		Message:        processInfo.Message,
+		IsIllegal:      processInfo.IsIllegal,
+		DetectedAt:     detectedAt,
+		RawPayload: map[string]any{
+			"process_info":  processInfo,
+			"reported_from": "procscan",
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.adminTimeout())
+	defer cancel()
+
+	return postJSON(ctx, s.adminEndpoint(), payload)
+}
+
+func (s *Scanner) adminEndpoint() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	baseURL := strings.TrimSpace(s.config.Notifications.Admin.BaseURL)
+	if baseURL == "" {
+		baseURL = defaultAdminBaseURL
+	}
+	return strings.TrimRight(baseURL, "/") + adminViolationsPath
+}
+
+func (s *Scanner) adminTimeout() time.Duration {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.config.Notifications.Admin.Timeout > 0 {
+		return s.config.Notifications.Admin.Timeout
+	}
+	return defaultAdminTimeout
+}
+
+func postJSON(ctx context.Context, endpoint string, payload any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func parseMatchDetails(message string) (string, string) {
+	message = strings.TrimSpace(message)
+	if strings.HasPrefix(message, "Process name '") && strings.Contains(message, "' matched blacklist rule '") {
+		parts := strings.SplitN(strings.TrimPrefix(message, "Process name '"), "' matched blacklist rule '", 2)
+		if len(parts) == 2 {
+			return "process_name", strings.TrimSuffix(parts[1], "'")
+		}
+	}
+	if strings.HasPrefix(message, "Command line matched keyword blacklist rule '") {
+		return "command_keyword", strings.TrimSuffix(strings.TrimPrefix(message, "Command line matched keyword blacklist rule '"), "'")
+	}
+	return "", ""
+}
+
+func currentNodeName() string {
+	nodeName := strings.TrimSpace(os.Getenv("NODE_NAME"))
+	if nodeName == "" {
+		return "unknown"
+	}
+	return nodeName
+}

--- a/procscan/internal/core/scanner/scanner.go
+++ b/procscan/internal/core/scanner/scanner.go
@@ -278,42 +278,29 @@ func (s *Scanner) scanProcesses() error {
 	}
 
 	if len(resultsByNamespace) == 0 {
-		legacy.L.Info("No process samples found in this scan round")
+		legacy.L.Info("Scan round found 0 suspicious processes")
 		return nil
-	}
-
-	illegalResultsByNamespace := make(map[string][]*models.ProcessInfo)
-	for namespace, processInfos := range resultsByNamespace {
-		illegalProcessInfos := filterIllegalProcessInfos(processInfos)
-		if len(illegalProcessInfos) > 0 {
-			illegalResultsByNamespace[namespace] = illegalProcessInfos
-		}
 	}
 
 	// Record suspicious process metrics
 	if s.metrics != nil {
-		for namespace, processInfos := range illegalResultsByNamespace {
+		for namespace, processInfos := range resultsByNamespace {
 			s.metrics.RecordSuspiciousProcesses(len(processInfos), namespace)
 		}
 	}
 
 	legacy.L.WithFields(logrus.Fields{
-		"namespaces_with_samples": len(resultsByNamespace),
-		"namespaces_with_illegal": len(illegalResultsByNamespace),
-	}).Info("Found process samples, starting grouped processing...")
+		"namespaces_with_violations": len(resultsByNamespace),
+	}).Info("Found suspicious processes, starting grouped processing...")
 
-	finalResults := make([]*alert.NamespaceScanResult, 0, len(illegalResultsByNamespace))
+	finalResults := make([]*alert.NamespaceScanResult, 0, len(resultsByNamespace))
 	for namespace, processInfos := range resultsByNamespace {
 		s.reportProcscanViolations(processInfos)
-		illegalProcessInfos := illegalResultsByNamespace[namespace]
-		if len(illegalProcessInfos) == 0 {
-			continue
-		}
 
 		labelResult := s.handleGroupedActions(namespace, currentConfig)
 		finalResults = append(finalResults, &alert.NamespaceScanResult{
 			Namespace:    namespace,
-			ProcessInfos: illegalProcessInfos,
+			ProcessInfos: processInfos,
 			LabelResult:  labelResult,
 		})
 	}
@@ -326,16 +313,6 @@ func (s *Scanner) scanProcesses() error {
 
 	legacy.L.Info("Scan round completed")
 	return nil
-}
-
-func filterIllegalProcessInfos(processInfos []*models.ProcessInfo) []*models.ProcessInfo {
-	illegalProcessInfos := make([]*models.ProcessInfo, 0, len(processInfos))
-	for _, processInfo := range processInfos {
-		if processInfo != nil && processInfo.IsIllegal {
-			illegalProcessInfos = append(illegalProcessInfos, processInfo)
-		}
-	}
-	return illegalProcessInfos
 }
 
 func (s *Scanner) handleGroupedActions(namespace string, config *models.Config) (labelResult string) {

--- a/procscan/internal/core/scanner/scanner.go
+++ b/procscan/internal/core/scanner/scanner.go
@@ -278,34 +278,64 @@ func (s *Scanner) scanProcesses() error {
 	}
 
 	if len(resultsByNamespace) == 0 {
-		legacy.L.Info("No suspicious processes found in this scan round")
+		legacy.L.Info("No process samples found in this scan round")
 		return nil
+	}
+
+	illegalResultsByNamespace := make(map[string][]*models.ProcessInfo)
+	for namespace, processInfos := range resultsByNamespace {
+		illegalProcessInfos := filterIllegalProcessInfos(processInfos)
+		if len(illegalProcessInfos) > 0 {
+			illegalResultsByNamespace[namespace] = illegalProcessInfos
+		}
 	}
 
 	// Record suspicious process metrics
 	if s.metrics != nil {
-		for namespace, processInfos := range resultsByNamespace {
+		for namespace, processInfos := range illegalResultsByNamespace {
 			s.metrics.RecordSuspiciousProcesses(len(processInfos), namespace)
 		}
 	}
 
-	legacy.L.WithField("count", len(resultsByNamespace)).Info("Found namespaces with suspicious processes, starting grouped processing...")
-	finalResults := make([]*alert.NamespaceScanResult, 0, len(resultsByNamespace))
+	legacy.L.WithFields(logrus.Fields{
+		"namespaces_with_samples": len(resultsByNamespace),
+		"namespaces_with_illegal": len(illegalResultsByNamespace),
+	}).Info("Found process samples, starting grouped processing...")
+
+	finalResults := make([]*alert.NamespaceScanResult, 0, len(illegalResultsByNamespace))
 	for namespace, processInfos := range resultsByNamespace {
+		s.reportProcscanViolations(processInfos)
+		illegalProcessInfos := illegalResultsByNamespace[namespace]
+		if len(illegalProcessInfos) == 0 {
+			continue
+		}
+
 		labelResult := s.handleGroupedActions(namespace, currentConfig)
 		finalResults = append(finalResults, &alert.NamespaceScanResult{
 			Namespace:    namespace,
-			ProcessInfos: processInfos,
+			ProcessInfos: illegalProcessInfos,
 			LabelResult:  labelResult,
 		})
 	}
 
-	if err := alert.SendGlobalBatchAlert(finalResults, currentConfig.Notifications.Lark.Webhook, currentConfig.Notifications.Region); err != nil {
-		legacy.L.WithError(err).Error("Failed to send global batch Lark alert")
+	if len(finalResults) > 0 {
+		if err := alert.SendGlobalBatchAlert(finalResults, currentConfig.Notifications.Lark.Webhook, currentConfig.Notifications.Region); err != nil {
+			legacy.L.WithError(err).Error("Failed to send global batch Lark alert")
+		}
 	}
 
 	legacy.L.Info("Scan round completed")
 	return nil
+}
+
+func filterIllegalProcessInfos(processInfos []*models.ProcessInfo) []*models.ProcessInfo {
+	illegalProcessInfos := make([]*models.ProcessInfo, 0, len(processInfos))
+	for _, processInfo := range processInfos {
+		if processInfo != nil && processInfo.IsIllegal {
+			illegalProcessInfos = append(illegalProcessInfos, processInfo)
+		}
+	}
+	return illegalProcessInfos
 }
 
 func (s *Scanner) handleGroupedActions(namespace string, config *models.Config) (labelResult string) {

--- a/procscan/pkg/models/models.go
+++ b/procscan/pkg/models/models.go
@@ -45,10 +45,17 @@ type LarkNotificationConfig struct {
 	Webhook string `yaml:"webhook"`
 }
 
+// AdminNotificationConfig contains configuration for the admin API.
+type AdminNotificationConfig struct {
+	BaseURL string        `yaml:"base_url"`
+	Timeout time.Duration `yaml:"timeout"`
+}
+
 // NotificationsConfig aggregates all notification channels
 type NotificationsConfig struct {
-	Lark   LarkNotificationConfig `yaml:"lark"`
-	Region string                 `yaml:"region"`
+	Lark   LarkNotificationConfig  `yaml:"lark"`
+	Admin  AdminNotificationConfig `yaml:"admin"`
+	Region string                  `yaml:"region"`
 }
 
 // MetricsConfig contains configuration for Prometheus metrics
@@ -88,7 +95,7 @@ type Config struct {
 
 // --- Business data models ---
 
-// ProcessInfo stores complete information for a single detected suspicious process
+// ProcessInfo stores complete information for a single detected process sample.
 type ProcessInfo struct {
 	PID         int
 	ProcessName string
@@ -98,4 +105,5 @@ type ProcessInfo struct {
 	ContainerID string
 	Timestamp   string
 	Message     string
+	IsIllegal   bool
 }

--- a/procscan/pkg/models/models.go
+++ b/procscan/pkg/models/models.go
@@ -95,7 +95,7 @@ type Config struct {
 
 // --- Business data models ---
 
-// ProcessInfo stores complete information for a single detected process sample.
+// ProcessInfo stores complete information for a detected suspicious process.
 type ProcessInfo struct {
 	PID         int
 	ProcessName string


### PR DESCRIPTION
## Summary

Add Admin API reporting for procscan violations and related configuration.

## Changes

- Report detected illegal processes to `/api/procscan-violations`
- Include namespace, pod, container, node, PID, process name, command, and matched rule
- Add `notifications.admin.base_url` and `timeout` config
- Update Helm values, configmap, and local config
- Fix related lint and test issues