### PR TITLE
feat(complik): report detector events to admin

### DIFF
--- a/complik/cmd/complik/main.go
+++ b/complik/cmd/complik/main.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/bearslyricattack/CompliK/complik/plugins/discovery/informer/deployment"
 	_ "github.com/bearslyricattack/CompliK/complik/plugins/discovery/informer/endPointSlice"
 	_ "github.com/bearslyricattack/CompliK/complik/plugins/discovery/informer/statefulset"
+	_ "github.com/bearslyricattack/CompliK/complik/plugins/handle/admin/reporter"
 	_ "github.com/bearslyricattack/CompliK/complik/plugins/handle/database/postages"
 	_ "github.com/bearslyricattack/CompliK/complik/plugins/handle/lark"
 )

--- a/complik/config.yml
+++ b/complik/config.yml
@@ -93,6 +93,16 @@ plugins:
         "password": "${POSTGRES_PASSWORD}"
       }
 
+  - name: "AdminReporter"
+    type: "Handle"
+    enabled: true
+    settings: |
+      {
+        "region": "${REGION}",
+        "adminBaseURL": "http://sealos-complik-admin:8080",
+        "adminTimeoutSecond": 10
+      }
+
   - name: "Lark"
     type: "Handle"
     enabled: true

--- a/complik/deploy/deploy/charts/complik/templates/configmap.yaml
+++ b/complik/deploy/deploy/charts/complik/templates/configmap.yaml
@@ -93,6 +93,15 @@ data:
             "username": {{ .Values.external.database.username | quote }},
             "password": {{ .Values.external.database.password | quote }}
           }
+      - name: "AdminReporter"
+        type: "Handle"
+        enabled: {{ .Values.plugins.adminReporter.enabled }}
+        settings: |
+          {
+            "region": {{ .Values.external.region | quote }},
+            "adminBaseURL": {{ .Values.external.admin.baseURL | quote }},
+            "adminTimeoutSecond": {{ .Values.external.admin.timeoutSecond }}
+          }
       - name: "Lark"
         type: "Handle"
         enabled: {{ .Values.plugins.lark.enabled }}

--- a/complik/deploy/deploy/charts/complik/values.yaml
+++ b/complik/deploy/deploy/charts/complik/values.yaml
@@ -44,6 +44,10 @@ external:
   lark:
     webhook: ""
 
+  admin:
+    baseURL: "http://sealos-complik-admin:8080"
+    timeoutSecond: 10
+
 plugins:
   complete:
     enabled: true
@@ -86,6 +90,9 @@ plugins:
     tableName: "CustomKeywordRule"
 
   postgres:
+    enabled: true
+
+  adminReporter:
     enabled: true
 
   lark:

--- a/complik/deploy/manifests/deploy.yaml
+++ b/complik/deploy/manifests/deploy.yaml
@@ -102,6 +102,16 @@ data:
             "password": ""
           }
 
+      - name: "AdminReporter"
+        type: "Handle"
+        enabled: true
+        settings: |
+          {
+            "region": "hzh",
+            "adminBaseURL": "http://sealos-complik-admin:8080",
+            "adminTimeoutSecond": 10
+          }
+
       - name: "Lark"
         type: "Handle"
         enabled: true

--- a/complik/pkg/constants/pluginName.go
+++ b/complik/pkg/constants/pluginName.go
@@ -34,5 +34,6 @@ const (
 
 const (
 	HandleDatabasePostgres = "Postgres"
+	HandleAdminReporter    = "AdminReporter"
 	HandleLark             = "Lark"
 )

--- a/complik/pkg/constants/pluginType.go
+++ b/complik/pkg/constants/pluginType.go
@@ -27,5 +27,6 @@ const (
 
 const (
 	HandleDatabasePluginType = "Handle.Database"
+	HandleAdminPluginType    = "Handle.Admin"
 	HandleLarkPluginType     = "Handle.Lark"
 )

--- a/complik/plugins/handle/admin/reporter/plugin.go
+++ b/complik/plugins/handle/admin/reporter/plugin.go
@@ -1,0 +1,269 @@
+// Copyright 2025 CompliK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/bearslyricattack/CompliK/complik/pkg/constants"
+	"github.com/bearslyricattack/CompliK/complik/pkg/eventbus"
+	"github.com/bearslyricattack/CompliK/complik/pkg/logger"
+	"github.com/bearslyricattack/CompliK/complik/pkg/models"
+	"github.com/bearslyricattack/CompliK/complik/pkg/plugin"
+	"github.com/bearslyricattack/CompliK/complik/pkg/utils/config"
+)
+
+const (
+	pluginName             = constants.HandleAdminReporter
+	pluginType             = constants.HandleAdminPluginType
+	defaultAdminBaseURL    = "http://sealos-complik-admin:8080"
+	defaultAdminTimeoutSec = 10
+	complikViolationsPath  = "/api/complik-violations"
+)
+
+func init() {
+	plugin.PluginFactories[pluginName] = func() plugin.Plugin {
+		return &AdminReporterPlugin{
+			log: logger.GetLogger().WithField("plugin", pluginName),
+		}
+	}
+}
+
+type AdminReporterPlugin struct {
+	log            logger.Logger
+	reporterConfig ReporterConfig
+}
+
+type ReporterConfig struct {
+	Region             string `json:"region"`
+	AdminBaseURL       string `json:"adminBaseURL"`
+	AdminTimeoutSecond int    `json:"adminTimeoutSecond"`
+}
+
+type complikViolationRequest struct {
+	Namespace     string    `json:"namespace"`
+	Region        string    `json:"region,omitempty"`
+	DiscoveryName string    `json:"discovery_name,omitempty"`
+	CollectorName string    `json:"collector_name,omitempty"`
+	DetectorName  string    `json:"detector_name"`
+	ResourceName  string    `json:"resource_name,omitempty"`
+	Host          string    `json:"host,omitempty"`
+	URL           string    `json:"url,omitempty"`
+	Path          []string  `json:"path,omitempty"`
+	Keywords      []string  `json:"keywords,omitempty"`
+	Description   string    `json:"description,omitempty"`
+	Explanation   string    `json:"explanation,omitempty"`
+	IsIllegal     bool      `json:"is_illegal"`
+	IsTest        bool      `json:"is_test"`
+	Status        string    `json:"status"`
+	DetectedAt    time.Time `json:"detected_at"`
+	RawPayload    any       `json:"raw_payload,omitempty"`
+}
+
+func (p *AdminReporterPlugin) Name() string {
+	return pluginName
+}
+
+func (p *AdminReporterPlugin) Type() string {
+	return pluginType
+}
+
+func (p *AdminReporterPlugin) getDefaultConfig() ReporterConfig {
+	return ReporterConfig{
+		Region:             "UNKNOWN",
+		AdminBaseURL:       defaultAdminBaseURL,
+		AdminTimeoutSecond: defaultAdminTimeoutSec,
+	}
+}
+
+func (p *AdminReporterPlugin) loadConfig(setting string) error {
+	p.reporterConfig = p.getDefaultConfig()
+	if strings.TrimSpace(setting) == "" {
+		return errors.New("configuration cannot be empty")
+	}
+
+	var configFromJSON ReporterConfig
+	if err := json.Unmarshal([]byte(setting), &configFromJSON); err != nil {
+		return err
+	}
+	if strings.TrimSpace(configFromJSON.Region) != "" {
+		p.reporterConfig.Region = strings.TrimSpace(configFromJSON.Region)
+	}
+	if strings.TrimSpace(configFromJSON.AdminBaseURL) != "" {
+		if secureValue, err := config.GetSecureValue(configFromJSON.AdminBaseURL); err == nil {
+			p.reporterConfig.AdminBaseURL = secureValue
+		} else {
+			p.reporterConfig.AdminBaseURL = configFromJSON.AdminBaseURL
+		}
+	}
+	if configFromJSON.AdminTimeoutSecond > 0 {
+		p.reporterConfig.AdminTimeoutSecond = configFromJSON.AdminTimeoutSecond
+	}
+
+	p.log.Info("Admin reporter configuration loaded", logger.Fields{
+		"region":         p.reporterConfig.Region,
+		"admin_base_url": p.reporterConfig.AdminBaseURL,
+		"admin_timeout":  p.reporterConfig.AdminTimeoutSecond,
+	})
+	return nil
+}
+
+func (p *AdminReporterPlugin) Start(
+	ctx context.Context,
+	cfg config.PluginConfig,
+	eventBus *eventbus.EventBus,
+) error {
+	if err := p.loadConfig(cfg.Settings); err != nil {
+		return err
+	}
+
+	subscribe := eventBus.Subscribe(constants.DetectorTopic)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				p.log.Error("Plugin goroutine panic", logger.Fields{"panic": r})
+			}
+		}()
+
+		for {
+			select {
+			case event, ok := <-subscribe:
+				if !ok {
+					p.log.Info("Event subscription channel closed")
+					return
+				}
+				result, ok := event.Payload.(*models.DetectorInfo)
+				if !ok {
+					p.log.Error("Invalid event payload type", logger.Fields{
+						"expected": "*models.DetectorInfo",
+						"actual":   fmt.Sprintf("%T", event.Payload),
+					})
+					continue
+				}
+				if strings.TrimSpace(result.Region) == "" {
+					result.Region = p.reporterConfig.Region
+				}
+				if err := p.reportViolation(result); err != nil {
+					p.log.Error("Failed to report detector event to admin", logger.Fields{
+						"error":     err.Error(),
+						"host":      result.Host,
+						"namespace": result.Namespace,
+					})
+				}
+			case <-ctx.Done():
+				p.log.Info("Plugin received stop signal")
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (p *AdminReporterPlugin) Stop(ctx context.Context) error {
+	return nil
+}
+
+func (p *AdminReporterPlugin) reportViolation(result *models.DetectorInfo) error {
+	if result == nil {
+		return fmt.Errorf("detector result is nil")
+	}
+	if strings.TrimSpace(result.Namespace) == "" {
+		return fmt.Errorf("namespace is required for admin reporting")
+	}
+
+	requestBody := complikViolationRequest{
+		Namespace:     result.Namespace,
+		Region:        result.Region,
+		DiscoveryName: result.DiscoveryName,
+		CollectorName: result.CollectorName,
+		DetectorName:  result.DetectorName,
+		ResourceName:  result.Name,
+		Host:          result.Host,
+		URL:           result.URL,
+		Path:          result.Path,
+		Keywords:      result.Keywords,
+		Description:   result.Description,
+		Explanation:   result.Explanation,
+		IsIllegal:     result.IsIllegal,
+		IsTest:        isComplikTestEvent(result),
+		Status:        "open",
+		DetectedAt:    time.Now().UTC(),
+		RawPayload:    result,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), p.adminTimeout())
+	defer cancel()
+
+	return postJSON(ctx, p.adminEndpoint(), requestBody)
+}
+
+func (p *AdminReporterPlugin) adminEndpoint() string {
+	return strings.TrimRight(p.reporterConfig.AdminBaseURL, "/") + complikViolationsPath
+}
+
+func (p *AdminReporterPlugin) adminTimeout() time.Duration {
+	timeoutSecond := p.reporterConfig.AdminTimeoutSecond
+	if timeoutSecond <= 0 {
+		timeoutSecond = defaultAdminTimeoutSec
+	}
+	return time.Duration(timeoutSecond) * time.Second
+}
+
+func isComplikTestEvent(result *models.DetectorInfo) bool {
+	if result == nil {
+		return false
+	}
+	if strings.EqualFold(result.Name, "程序启动，飞书通知测试") {
+		return true
+	}
+	for _, keyword := range result.Keywords {
+		if keyword == "程序启动" {
+			return true
+		}
+	}
+	return false
+}
+
+func postJSON(ctx context.Context, endpoint string, payload any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/complik/plugins/handle/admin/reporter/plugin.go
+++ b/complik/plugins/handle/admin/reporter/plugin.go
@@ -172,7 +172,7 @@ func (p *AdminReporterPlugin) Start(
 					result.Region = p.reporterConfig.Region
 				}
 
-				if err := p.reportViolation(result); err != nil {
+				if err := p.reportViolation(ctx, result); err != nil {
 					p.log.Error("Failed to report detector event to admin", logger.Fields{
 						"error":     err.Error(),
 						"host":      result.Host,
@@ -193,7 +193,10 @@ func (p *AdminReporterPlugin) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (p *AdminReporterPlugin) reportViolation(result *models.DetectorInfo) error {
+func (p *AdminReporterPlugin) reportViolation(
+	parentCtx context.Context,
+	result *models.DetectorInfo,
+) error {
 	if result == nil {
 		return errors.New("detector result is nil")
 	}
@@ -222,10 +225,10 @@ func (p *AdminReporterPlugin) reportViolation(result *models.DetectorInfo) error
 		RawPayload:    result,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), p.adminTimeout())
+	requestCtx, cancel := context.WithTimeout(parentCtx, p.adminTimeout())
 	defer cancel()
 
-	return postJSON(ctx, p.adminEndpoint(), requestBody)
+	return postJSON(requestCtx, p.adminEndpoint(), requestBody)
 }
 
 func (p *AdminReporterPlugin) adminEndpoint() string {

--- a/complik/plugins/handle/admin/reporter/plugin.go
+++ b/complik/plugins/handle/admin/reporter/plugin.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -97,6 +98,7 @@ func (p *AdminReporterPlugin) getDefaultConfig() ReporterConfig {
 
 func (p *AdminReporterPlugin) loadConfig(setting string) error {
 	p.reporterConfig = p.getDefaultConfig()
+
 	if strings.TrimSpace(setting) == "" {
 		return errors.New("configuration cannot be empty")
 	}
@@ -105,9 +107,11 @@ func (p *AdminReporterPlugin) loadConfig(setting string) error {
 	if err := json.Unmarshal([]byte(setting), &configFromJSON); err != nil {
 		return err
 	}
+
 	if strings.TrimSpace(configFromJSON.Region) != "" {
 		p.reporterConfig.Region = strings.TrimSpace(configFromJSON.Region)
 	}
+
 	if strings.TrimSpace(configFromJSON.AdminBaseURL) != "" {
 		if secureValue, err := config.GetSecureValue(configFromJSON.AdminBaseURL); err == nil {
 			p.reporterConfig.AdminBaseURL = secureValue
@@ -115,6 +119,7 @@ func (p *AdminReporterPlugin) loadConfig(setting string) error {
 			p.reporterConfig.AdminBaseURL = configFromJSON.AdminBaseURL
 		}
 	}
+
 	if configFromJSON.AdminTimeoutSecond > 0 {
 		p.reporterConfig.AdminTimeoutSecond = configFromJSON.AdminTimeoutSecond
 	}
@@ -124,6 +129,7 @@ func (p *AdminReporterPlugin) loadConfig(setting string) error {
 		"admin_base_url": p.reporterConfig.AdminBaseURL,
 		"admin_timeout":  p.reporterConfig.AdminTimeoutSecond,
 	})
+
 	return nil
 }
 
@@ -151,17 +157,21 @@ func (p *AdminReporterPlugin) Start(
 					p.log.Info("Event subscription channel closed")
 					return
 				}
+
 				result, ok := event.Payload.(*models.DetectorInfo)
 				if !ok {
 					p.log.Error("Invalid event payload type", logger.Fields{
 						"expected": "*models.DetectorInfo",
 						"actual":   fmt.Sprintf("%T", event.Payload),
 					})
+
 					continue
 				}
+
 				if strings.TrimSpace(result.Region) == "" {
 					result.Region = p.reporterConfig.Region
 				}
+
 				if err := p.reportViolation(result); err != nil {
 					p.log.Error("Failed to report detector event to admin", logger.Fields{
 						"error":     err.Error(),
@@ -185,10 +195,11 @@ func (p *AdminReporterPlugin) Stop(ctx context.Context) error {
 
 func (p *AdminReporterPlugin) reportViolation(result *models.DetectorInfo) error {
 	if result == nil {
-		return fmt.Errorf("detector result is nil")
+		return errors.New("detector result is nil")
 	}
+
 	if strings.TrimSpace(result.Namespace) == "" {
-		return fmt.Errorf("namespace is required for admin reporting")
+		return errors.New("namespace is required for admin reporting")
 	}
 
 	requestBody := complikViolationRequest{
@@ -226,6 +237,7 @@ func (p *AdminReporterPlugin) adminTimeout() time.Duration {
 	if timeoutSecond <= 0 {
 		timeoutSecond = defaultAdminTimeoutSec
 	}
+
 	return time.Duration(timeoutSecond) * time.Second
 }
 
@@ -233,15 +245,12 @@ func isComplikTestEvent(result *models.DetectorInfo) bool {
 	if result == nil {
 		return false
 	}
+
 	if strings.EqualFold(result.Name, "程序启动，飞书通知测试") {
 		return true
 	}
-	for _, keyword := range result.Keywords {
-		if keyword == "程序启动" {
-			return true
-		}
-	}
-	return false
+
+	return slices.Contains(result.Keywords, "程序启动")
 }
 
 func postJSON(ctx context.Context, endpoint string, payload any) error {
@@ -254,6 +263,7 @@ func postJSON(ctx context.Context, endpoint string, payload any) error {
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
+
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -265,5 +275,6 @@ func postJSON(ctx context.Context, endpoint string, payload any) error {
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
+
 	return nil
 }

--- a/complik/plugins/handle/admin/reporter/plugin.go
+++ b/complik/plugins/handle/admin/reporter/plugin.go
@@ -169,10 +169,6 @@ func (p *AdminReporterPlugin) Start(
 					continue
 				}
 
-				if strings.TrimSpace(result.Region) == "" {
-					result.Region = p.reporterConfig.Region
-				}
-
 				if err := p.reportViolation(ctx, result); err != nil {
 					p.log.Error("Failed to report detector event to admin", logger.Fields{
 						"error":     err.Error(),
@@ -206,9 +202,14 @@ func (p *AdminReporterPlugin) reportViolation(
 		return errors.New("namespace is required for admin reporting")
 	}
 
+	region := strings.TrimSpace(result.Region)
+	if region == "" {
+		region = p.reporterConfig.Region
+	}
+
 	requestBody := complikViolationRequest{
 		Namespace:     result.Namespace,
-		Region:        result.Region,
+		Region:        region,
 		DiscoveryName: result.DiscoveryName,
 		CollectorName: result.CollectorName,
 		DetectorName:  result.DetectorName,

--- a/complik/plugins/handle/admin/reporter/plugin.go
+++ b/complik/plugins/handle/admin/reporter/plugin.go
@@ -144,6 +144,7 @@ func (p *AdminReporterPlugin) Start(
 
 	subscribe := eventBus.Subscribe(constants.DetectorTopic)
 	go func() {
+		defer eventBus.Unsubscribe(constants.DetectorTopic, subscribe)
 		defer func() {
 			if r := recover(); r != nil {
 				p.log.Error("Plugin goroutine panic", logger.Fields{"panic": r})


### PR DESCRIPTION
## Summary

Add an AdminReporter plugin to report CompliK detector events to Admin API.

## Changes

- Add `AdminReporter` handle plugin
- Subscribe to detector events from `DetectorTopic`
- Report detector results to `/api/complik-violations`
- Include namespace, region, detector info, resource info, violation status, detected time, and raw payload
- Add Admin reporter config to local config, manifests, and Helm chart
- Register the plugin in CompliK startup
