### PR TITLE
fix(complik): repair browser launch and endpointslice payload

### DIFF
--- a/complik/Dockerfile
+++ b/complik/Dockerfile
@@ -23,7 +23,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM debian:bookworm-slim
 
 ENV CHROME_BIN=/usr/bin/chromium \
-    ROD_BROWSER_BIN=/usr/bin/chromium
+    ROD_BROWSER_BIN=/usr/bin/chromium \
+    HOME=/tmp \
+    XDG_CACHE_HOME=/tmp/.cache
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -35,6 +37,8 @@ COPY --from=builder /out/manager /manager
 
 RUN echo "nonroot:x:65532:" >> /etc/group && \
     echo "nonroot:x:65532:65532:nonroot:/nonexistent:/usr/sbin/nologin" >> /etc/passwd && \
+    mkdir -p /tmp/.cache/rod && \
+    chmod 1777 /tmp/.cache /tmp/.cache/rod && \
     chmod +x /manager
 
 EXPOSE 8428

--- a/complik/deploy/deploy/charts/complik/templates/deployment.yaml
+++ b/complik/deploy/deploy/charts/complik/templates/deployment.yaml
@@ -35,6 +35,12 @@ spec:
             - containerPort: {{ .Values.containerPort }}
               protocol: TCP
           env:
+            - name: HOME
+              value: {{ .Values.browserRuntime.home | quote }}
+            - name: XDG_CACHE_HOME
+              value: {{ .Values.browserRuntime.cacheHome | quote }}
+            - name: ROD_BROWSER_BIN
+              value: {{ .Values.browserRuntime.bin | quote }}
             - name: USE_SERVICE_ACCOUNT
               value: {{ .Values.kubeconfig.useServiceAccount | quote }}
             {{- if not .Values.kubeconfig.useServiceAccount }}

--- a/complik/deploy/deploy/charts/complik/values.yaml
+++ b/complik/deploy/deploy/charts/complik/values.yaml
@@ -20,6 +20,11 @@ resources:
 
 containerPort: 8428
 
+browserRuntime:
+  home: /tmp
+  cacheHome: /tmp/.cache
+  bin: /usr/bin/chromium
+
 database:
   create: true
 

--- a/complik/deploy/manifests/deploy.yaml
+++ b/complik/deploy/manifests/deploy.yaml
@@ -157,6 +157,13 @@ spec:
           image: bearslyricattack/sealos-complik-service:latest
           imagePullPolicy: Always
           name: service-complik
+          env:
+            - name: HOME
+              value: /tmp
+            - name: XDG_CACHE_HOME
+              value: /tmp/.cache
+            - name: ROD_BROWSER_BIN
+              value: /usr/bin/chromium
           ports:
             - containerPort: 8428
               protocol: TCP

--- a/complik/plugins/compliance/collector/browser/utils/browserPool.go
+++ b/complik/plugins/compliance/collector/browser/utils/browserPool.go
@@ -21,6 +21,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
@@ -162,6 +165,13 @@ func (p *BrowserPool) createInstance() (*BrowserInstance, error) {
 		Set("disable-features", "VizDisplayCompositor").
 		Headless(true)
 
+	if browserBin := configuredBrowserBin(p.log); browserBin != "" {
+		l = l.Bin(browserBin)
+		p.log.Debug("Using configured browser binary", logger.Fields{
+			"browser_bin": browserBin,
+		})
+	}
+
 	u, err := l.Launch()
 	if err != nil {
 		p.log.Error("Failed to launch browser", logger.Fields{
@@ -187,6 +197,58 @@ func (p *BrowserPool) createInstance() (*BrowserInstance, error) {
 	})
 
 	return instance, nil
+}
+
+func configuredBrowserBin(log logger.Logger) string {
+	for _, name := range []string{"ROD_BROWSER_BIN", "CHROME_BIN"} {
+		value := strings.TrimSpace(os.Getenv(name))
+		if value == "" {
+			continue
+		}
+		if browserBin, ok := usableBrowserBin(value); ok {
+			return browserBin
+		}
+		if log != nil {
+			log.Warn("Configured browser binary is not usable", logger.Fields{
+				"env":         name,
+				"browser_bin": value,
+			})
+		}
+	}
+
+	for _, path := range []string{
+		"/usr/bin/chromium",
+		"/usr/bin/chromium-browser",
+		"/usr/bin/google-chrome",
+		"/usr/bin/google-chrome-stable",
+	} {
+		if browserBin, ok := usableBrowserBin(path); ok {
+			return browserBin
+		}
+	}
+
+	return ""
+}
+
+func usableBrowserBin(candidate string) (string, bool) {
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" {
+		return "", false
+	}
+
+	if !strings.Contains(candidate, string(os.PathSeparator)) {
+		path, err := exec.LookPath(candidate)
+		if err != nil {
+			return "", false
+		}
+		return path, true
+	}
+
+	info, err := os.Stat(candidate)
+	if err != nil || info.IsDir() || info.Mode().Perm()&0111 == 0 {
+		return "", false
+	}
+	return candidate, true
 }
 
 func (p *BrowserPool) cleanupExpired() {

--- a/complik/plugins/discovery/informer/endPointSlice/plugin.go
+++ b/complik/plugins/discovery/informer/endPointSlice/plugin.go
@@ -24,6 +24,7 @@ import (
 	"github.com/bearslyricattack/CompliK/complik/pkg/eventbus"
 	"github.com/bearslyricattack/CompliK/complik/pkg/k8s"
 	"github.com/bearslyricattack/CompliK/complik/pkg/logger"
+	"github.com/bearslyricattack/CompliK/complik/pkg/models"
 	"github.com/bearslyricattack/CompliK/complik/pkg/plugin"
 	"github.com/bearslyricattack/CompliK/complik/pkg/utils/config"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -492,11 +493,51 @@ func (p *EndPointInformerPlugin) handleEndpointSliceEvent(endpointInfo *Endpoint
 		"matchedIngresses": len(endpointInfo.MatchedIngresses),
 	})
 
-	p.eventBus.Publish(constants.DiscoveryTopic, eventbus.Event{
-		Payload: endpointInfo,
-	})
+	for _, info := range p.buildDiscoveryInfo(endpointInfo) {
+		p.eventBus.Publish(constants.DiscoveryTopic, eventbus.Event{
+			Payload: info,
+		})
+	}
 
 	p.log.Debug("EndpointSlice event published successfully")
+}
+
+func (p *EndPointInformerPlugin) buildDiscoveryInfo(
+	endpointInfo *EndpointSliceInfo,
+) []models.DiscoveryInfo {
+	if endpointInfo == nil {
+		return nil
+	}
+
+	discoveryInfos := make([]models.DiscoveryInfo, 0, len(endpointInfo.MatchedIngresses))
+	for _, ingressInfo := range endpointInfo.MatchedIngresses {
+		discoveryInfos = append(discoveryInfos, models.DiscoveryInfo{
+			DiscoveryName: p.Name(),
+			Name:          ingressInfo.Name,
+			Namespace:     ingressInfo.Namespace,
+			Host:          normalizedIngressHost(ingressInfo.Host),
+			Path:          []string{normalizedIngressPath(ingressInfo.Path)},
+			ServiceName:   endpointInfo.ServiceName,
+			HasActivePods: endpointInfo.ReadyCount > 0,
+			PodCount:      endpointInfo.ReadyCount,
+		})
+	}
+
+	return discoveryInfos
+}
+
+func normalizedIngressHost(host string) string {
+	if host == "" {
+		return "*"
+	}
+	return host
+}
+
+func normalizedIngressPath(path string) string {
+	if path == "" {
+		return "/"
+	}
+	return path
 }
 
 func (p *EndPointInformerPlugin) checkServiceHasIngress(
@@ -543,13 +584,6 @@ func (p *EndPointInformerPlugin) checkServiceHasIngress(
 						Namespace: ingress.Namespace,
 						Host:      rule.Host,
 						Path:      path.Path,
-					}
-					if ingressInfo.Path == "" {
-						ingressInfo.Path = "/"
-					}
-
-					if ingressInfo.Host == "" {
-						ingressInfo.Host = "*"
 					}
 
 					p.log.Debug("Found matching ingress path", logger.Fields{


### PR DESCRIPTION
## What

Fix CompliK browser startup and EndpointSlice discovery payloads.

## Changes

- Configure Chromium runtime env and writable Rod cache directory
- Resolve browser binary from env or common Chromium paths
- Publish EndpointSlice discoveries as `DiscoveryInfo` payloads
- Normalize empty ingress host and path values
