### PR TITLE
feat: add admin basic auth to CompliK and Procscan

### DIFF
--- a/complik/config.yml
+++ b/complik/config.yml
@@ -58,7 +58,9 @@ plugins:
       {
         "maxWorkers": 20,
         "adminBaseURL": "http://sealos-complik-admin:8080",
-        "adminTimeoutSecond": 10
+        "adminTimeoutSecond": 10,
+        "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",
+        "adminBasicAuthPassword": "${ADMIN_BASIC_AUTH_PASSWORD}"
       }
 
   - name: "Custom"
@@ -68,7 +70,9 @@ plugins:
       {
         "maxWorkers": 20,
         "adminBaseURL": "http://sealos-complik-admin:8080",
-        "adminTimeoutSecond": 10
+        "adminTimeoutSecond": 10,
+        "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",
+        "adminBasicAuthPassword": "${ADMIN_BASIC_AUTH_PASSWORD}"
       }
 
   - name: "AdminReporter"
@@ -78,7 +82,9 @@ plugins:
       {
         "region": "${REGION}",
         "adminBaseURL": "http://sealos-complik-admin:8080",
-        "adminTimeoutSecond": 10
+        "adminTimeoutSecond": 10,
+        "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",
+        "adminBasicAuthPassword": "${ADMIN_BASIC_AUTH_PASSWORD}"
       }
 
   - name: "Lark"
@@ -88,7 +94,9 @@ plugins:
       {
         "region": "${REGION}",
         "adminBaseURL": "http://sealos-complik-admin:8080",
-        "adminTimeoutSecond": 10
+        "adminTimeoutSecond": 10,
+        "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",
+        "adminBasicAuthPassword": "${ADMIN_BASIC_AUTH_PASSWORD}"
       }
 
 logging:

--- a/complik/deploy/deploy/charts/complik/templates/configmap.yaml
+++ b/complik/deploy/deploy/charts/complik/templates/configmap.yaml
@@ -61,7 +61,9 @@ data:
           {
             "maxWorkers": {{ .Values.plugins.safety.maxWorkers }},
             "adminBaseURL": {{ .Values.external.admin.baseURL | quote }},
-            "adminTimeoutSecond": {{ .Values.external.admin.timeoutSecond }}
+            "adminTimeoutSecond": {{ .Values.external.admin.timeoutSecond }},
+            "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",
+            "adminBasicAuthPassword": "${ADMIN_BASIC_AUTH_PASSWORD}"
           }
       - name: "Custom"
         type: "Compliance"
@@ -70,7 +72,9 @@ data:
           {
             "maxWorkers": {{ .Values.plugins.custom.maxWorkers }},
             "adminBaseURL": {{ .Values.external.admin.baseURL | quote }},
-            "adminTimeoutSecond": {{ .Values.external.admin.timeoutSecond }}
+            "adminTimeoutSecond": {{ .Values.external.admin.timeoutSecond }},
+            "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",
+            "adminBasicAuthPassword": "${ADMIN_BASIC_AUTH_PASSWORD}"
           }
       - name: "AdminReporter"
         type: "Handle"
@@ -79,7 +83,9 @@ data:
           {
             "region": {{ .Values.external.region | quote }},
             "adminBaseURL": {{ .Values.external.admin.baseURL | quote }},
-            "adminTimeoutSecond": {{ .Values.external.admin.timeoutSecond }}
+            "adminTimeoutSecond": {{ .Values.external.admin.timeoutSecond }},
+            "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",
+            "adminBasicAuthPassword": "${ADMIN_BASIC_AUTH_PASSWORD}"
           }
       - name: "Lark"
         type: "Handle"
@@ -88,7 +94,9 @@ data:
           {
             "region": {{ .Values.external.region | quote }},
             "adminBaseURL": {{ .Values.external.admin.baseURL | quote }},
-            "adminTimeoutSecond": {{ .Values.external.admin.timeoutSecond }}
+            "adminTimeoutSecond": {{ .Values.external.admin.timeoutSecond }},
+            "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",
+            "adminBasicAuthPassword": "${ADMIN_BASIC_AUTH_PASSWORD}"
           }
     logging:
       level: {{ .Values.config.logging.level | quote }}

--- a/complik/deploy/deploy/charts/complik/templates/deployment.yaml
+++ b/complik/deploy/deploy/charts/complik/templates/deployment.yaml
@@ -41,6 +41,18 @@ spec:
               value: {{ .Values.browserRuntime.cacheHome | quote }}
             - name: ROD_BROWSER_BIN
               value: {{ .Values.browserRuntime.bin | quote }}
+            {{- if .Values.external.admin.basicAuth.enabled }}
+            - name: ADMIN_BASIC_AUTH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.external.admin.basicAuth.secretName | quote }}
+                  key: {{ .Values.external.admin.basicAuth.usernameKey | quote }}
+            - name: ADMIN_BASIC_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.external.admin.basicAuth.secretName | quote }}
+                  key: {{ .Values.external.admin.basicAuth.passwordKey | quote }}
+            {{- end }}
             - name: USE_SERVICE_ACCOUNT
               value: {{ .Values.kubeconfig.useServiceAccount | quote }}
             {{- if not .Values.kubeconfig.useServiceAccount }}

--- a/complik/deploy/deploy/charts/complik/values.yaml
+++ b/complik/deploy/deploy/charts/complik/values.yaml
@@ -38,6 +38,11 @@ external:
   admin:
     baseURL: "http://sealos-complik-admin:8080"
     timeoutSecond: 10
+    basicAuth:
+      enabled: false
+      secretName: sealos-complik-admin-auth
+      usernameKey: username
+      passwordKey: password
 
 plugins:
   complete:

--- a/complik/deploy/deploy/charts/procscan/templates/configmap.yaml
+++ b/complik/deploy/deploy/charts/procscan/templates/configmap.yaml
@@ -22,3 +22,6 @@ data:
       admin:
         base_url: {{ .Values.config.notifications.admin.base_url | quote }}
         timeout: {{ .Values.config.notifications.admin.timeout | quote }}
+        basic_auth:
+          username: {{ .Values.config.notifications.admin.basic_auth.username | quote }}
+          password: {{ .Values.config.notifications.admin.basic_auth.password | quote }}

--- a/complik/deploy/deploy/charts/procscan/templates/daemonset.yaml
+++ b/complik/deploy/deploy/charts/procscan/templates/daemonset.yaml
@@ -47,6 +47,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.config.notifications.admin.basic_auth.env.enabled }}
+            - name: ADMIN_BASIC_AUTH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.notifications.admin.basic_auth.env.secretName | quote }}
+                  key: {{ .Values.config.notifications.admin.basic_auth.env.usernameKey | quote }}
+            - name: ADMIN_BASIC_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.notifications.admin.basic_auth.env.secretName | quote }}
+                  key: {{ .Values.config.notifications.admin.basic_auth.env.passwordKey | quote }}
+            {{- end }}
           securityContext:
             {{- toYaml .Values.daemonset.securityContext | nindent 12 }}
           volumeMounts:

--- a/complik/deploy/deploy/charts/procscan/values.yaml
+++ b/complik/deploy/deploy/charts/procscan/values.yaml
@@ -66,6 +66,14 @@ config:
     admin:
       base_url: "http://sealos-complik-admin:8080"
       timeout: "10s"
+      basic_auth:
+        username: "${ADMIN_BASIC_AUTH_USERNAME}"
+        password: "${ADMIN_BASIC_AUTH_PASSWORD}"
+        env:
+          enabled: false
+          secretName: sealos-complik-admin-auth
+          usernameKey: username
+          passwordKey: password
 
 volumes:
   proc:

--- a/complik/deploy/manifests/deploy.yaml
+++ b/complik/deploy/manifests/deploy.yaml
@@ -67,7 +67,9 @@ data:
           {
             "maxWorkers": 20,
             "adminBaseURL": "http://sealos-complik-admin:8080",
-            "adminTimeoutSecond": 10
+            "adminTimeoutSecond": 10,
+            "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",
+            "adminBasicAuthPassword": "${ADMIN_BASIC_AUTH_PASSWORD}"
           }
 
       - name: "Custom"
@@ -77,7 +79,9 @@ data:
           {
             "maxWorkers": 20,
             "adminBaseURL": "http://sealos-complik-admin:8080",
-            "adminTimeoutSecond": 10
+            "adminTimeoutSecond": 10,
+            "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",
+            "adminBasicAuthPassword": "${ADMIN_BASIC_AUTH_PASSWORD}"
           }
 
       - name: "AdminReporter"
@@ -87,7 +91,9 @@ data:
           {
             "region": "hzh",
             "adminBaseURL": "http://sealos-complik-admin:8080",
-            "adminTimeoutSecond": 10
+            "adminTimeoutSecond": 10,
+            "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",
+            "adminBasicAuthPassword": "${ADMIN_BASIC_AUTH_PASSWORD}"
           }
 
       - name: "Lark"
@@ -97,7 +103,9 @@ data:
           {
             "region": "hzh",
             "adminBaseURL": "http://sealos-complik-admin:8080",
-            "adminTimeoutSecond": 10
+            "adminTimeoutSecond": 10,
+            "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",
+            "adminBasicAuthPassword": "${ADMIN_BASIC_AUTH_PASSWORD}"
           }
     logging:
       level: "info"
@@ -164,6 +172,16 @@ spec:
               value: /tmp/.cache
             - name: ROD_BROWSER_BIN
               value: /usr/bin/chromium
+            - name: ADMIN_BASIC_AUTH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: sealos-complik-admin-auth
+                  key: username
+            - name: ADMIN_BASIC_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sealos-complik-admin-auth
+                  key: password
           ports:
             - containerPort: 8428
               protocol: TCP

--- a/complik/pkg/utils/config/admin_basic_auth.go
+++ b/complik/pkg/utils/config/admin_basic_auth.go
@@ -1,0 +1,65 @@
+// Copyright 2025 CompliK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	AdminBasicAuthUsernameEnv = "ADMIN_BASIC_AUTH_USERNAME"
+	AdminBasicAuthPasswordEnv = "ADMIN_BASIC_AUTH_PASSWORD"
+)
+
+type AdminBasicAuth struct {
+	Username string
+	Password string
+}
+
+func ResolveAdminBasicAuth(username, password string) AdminBasicAuth {
+	resolvedUsername := resolveOptionalSecureValue(username)
+	resolvedPassword := resolveOptionalSecureValue(password)
+	if resolvedUsername == "" {
+		resolvedUsername = strings.TrimSpace(os.Getenv(AdminBasicAuthUsernameEnv))
+	}
+	if resolvedPassword == "" {
+		resolvedPassword = strings.TrimSpace(os.Getenv(AdminBasicAuthPasswordEnv))
+	}
+	return AdminBasicAuth{
+		Username: resolvedUsername,
+		Password: resolvedPassword,
+	}
+}
+
+func (a AdminBasicAuth) Apply(req *http.Request) {
+	if req == nil || strings.TrimSpace(a.Username) == "" || strings.TrimSpace(a.Password) == "" {
+		return
+	}
+	req.SetBasicAuth(a.Username, a.Password)
+}
+
+func resolveOptionalSecureValue(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	resolved, err := GetSecureValue(trimmed)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(resolved)
+}

--- a/complik/pkg/utils/config/admin_project_config.go
+++ b/complik/pkg/utils/config/admin_project_config.go
@@ -78,11 +78,21 @@ func ListAdminProjectConfigs(
 	adminBaseURL string,
 	timeoutSecond int,
 ) ([]AdminProjectConfig, error) {
+	return ListAdminProjectConfigsWithAuth(ctx, adminBaseURL, timeoutSecond, ResolveAdminBasicAuth("", ""))
+}
+
+func ListAdminProjectConfigsWithAuth(
+	ctx context.Context,
+	adminBaseURL string,
+	timeoutSecond int,
+	auth AdminBasicAuth,
+) ([]AdminProjectConfig, error) {
 	endpoint := NormalizeAdminBaseURL(adminBaseURL) + "/api/configs"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create admin list request failed: %w", err)
 	}
+	auth.Apply(req)
 
 	resp, err := adminHTTPClient(timeoutSecond).Do(req)
 	if err != nil {
@@ -111,6 +121,22 @@ func ListAdminProjectConfigsByType(
 	timeoutSecond int,
 	configType string,
 ) ([]AdminProjectConfig, error) {
+	return ListAdminProjectConfigsByTypeWithAuth(
+		ctx,
+		adminBaseURL,
+		timeoutSecond,
+		configType,
+		ResolveAdminBasicAuth("", ""),
+	)
+}
+
+func ListAdminProjectConfigsByTypeWithAuth(
+	ctx context.Context,
+	adminBaseURL string,
+	timeoutSecond int,
+	configType string,
+	auth AdminBasicAuth,
+) ([]AdminProjectConfig, error) {
 	trimmedType := strings.TrimSpace(configType)
 	if trimmedType == "" {
 		return nil, fmt.Errorf("config_type is required")
@@ -121,6 +147,7 @@ func ListAdminProjectConfigsByType(
 	if err != nil {
 		return nil, fmt.Errorf("create admin list-by-type request failed: %w", err)
 	}
+	auth.Apply(req)
 
 	resp, err := adminHTTPClient(timeoutSecond).Do(req)
 	if err != nil {
@@ -153,7 +180,23 @@ func LoadSingleAdminProjectConfigByType(
 	timeoutSecond int,
 	configType string,
 ) (*AdminProjectConfig, error) {
-	cfgs, err := ListAdminProjectConfigsByType(ctx, adminBaseURL, timeoutSecond, configType)
+	return LoadSingleAdminProjectConfigByTypeWithAuth(
+		ctx,
+		adminBaseURL,
+		timeoutSecond,
+		configType,
+		ResolveAdminBasicAuth("", ""),
+	)
+}
+
+func LoadSingleAdminProjectConfigByTypeWithAuth(
+	ctx context.Context,
+	adminBaseURL string,
+	timeoutSecond int,
+	configType string,
+	auth AdminBasicAuth,
+) (*AdminProjectConfig, error) {
+	cfgs, err := ListAdminProjectConfigsByTypeWithAuth(ctx, adminBaseURL, timeoutSecond, configType, auth)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +221,22 @@ func LoadModelRuntimeConfig(
 	adminBaseURL string,
 	timeoutSecond int,
 ) (*ModelRuntimeConfig, error) {
-	cfg, err := LoadSingleAdminProjectConfigByType(ctx, adminBaseURL, timeoutSecond, "model_runtime")
+	return LoadModelRuntimeConfigWithAuth(ctx, adminBaseURL, timeoutSecond, ResolveAdminBasicAuth("", ""))
+}
+
+func LoadModelRuntimeConfigWithAuth(
+	ctx context.Context,
+	adminBaseURL string,
+	timeoutSecond int,
+	auth AdminBasicAuth,
+) (*ModelRuntimeConfig, error) {
+	cfg, err := LoadSingleAdminProjectConfigByTypeWithAuth(
+		ctx,
+		adminBaseURL,
+		timeoutSecond,
+		"model_runtime",
+		auth,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +259,22 @@ func LoadNotificationsRuntimeConfig(
 	adminBaseURL string,
 	timeoutSecond int,
 ) (*NotificationsRuntimeConfig, error) {
-	cfg, err := LoadSingleAdminProjectConfigByType(ctx, adminBaseURL, timeoutSecond, "complik_notifications_runtime")
+	return LoadNotificationsRuntimeConfigWithAuth(ctx, adminBaseURL, timeoutSecond, ResolveAdminBasicAuth("", ""))
+}
+
+func LoadNotificationsRuntimeConfigWithAuth(
+	ctx context.Context,
+	adminBaseURL string,
+	timeoutSecond int,
+	auth AdminBasicAuth,
+) (*NotificationsRuntimeConfig, error) {
+	cfg, err := LoadSingleAdminProjectConfigByTypeWithAuth(
+		ctx,
+		adminBaseURL,
+		timeoutSecond,
+		"complik_notifications_runtime",
+		auth,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/complik/plugins/compliance/detector/custom/plugin.go
+++ b/complik/plugins/compliance/detector/custom/plugin.go
@@ -63,13 +63,15 @@ func (p *CustomPlugin) Type() string {
 }
 
 type CustomConfig struct {
-	MaxWorkers         int    `json:"maxWorkers"`
-	APIKey             string `json:"apiKey"`
-	APIBase            string `json:"apiBase"`
-	APIPath            string `json:"apiPath"`
-	Model              string `json:"model"`
-	AdminBaseURL       string `json:"adminBaseURL"`
-	AdminTimeoutSecond int    `json:"adminTimeoutSecond"`
+	MaxWorkers             int    `json:"maxWorkers"`
+	APIKey                 string `json:"apiKey"`
+	APIBase                string `json:"apiBase"`
+	APIPath                string `json:"apiPath"`
+	Model                  string `json:"model"`
+	AdminBaseURL           string `json:"adminBaseURL"`
+	AdminTimeoutSecond     int    `json:"adminTimeoutSecond"`
+	AdminBasicAuthUsername string `json:"adminBasicAuthUsername"`
+	AdminBasicAuthPassword string `json:"adminBasicAuthPassword"`
 }
 
 func (p *CustomPlugin) getDefaultConfig() CustomConfig {
@@ -107,6 +109,7 @@ func (p *CustomPlugin) loadConfig(ctx context.Context, setting string) error {
 	if configFromJSON.AdminTimeoutSecond > 0 {
 		p.customConfig.AdminTimeoutSecond = configFromJSON.AdminTimeoutSecond
 	}
+	p.applyAdminBasicAuthConfig(configFromJSON)
 	if err := p.applyModelRuntimeConfig(ctx); err != nil {
 		return fmt.Errorf("failed to apply model runtime config from admin: %w", err)
 	}
@@ -128,6 +131,22 @@ func (p *CustomPlugin) loadConfig(ctx context.Context, setting string) error {
 		"keyword_count":  len(p.keywords),
 	})
 	return nil
+}
+
+func (p *CustomPlugin) applyAdminBasicAuthConfig(configFromJSON CustomConfig) {
+	auth := config.ResolveAdminBasicAuth(
+		configFromJSON.AdminBasicAuthUsername,
+		configFromJSON.AdminBasicAuthPassword,
+	)
+	p.customConfig.AdminBasicAuthUsername = auth.Username
+	p.customConfig.AdminBasicAuthPassword = auth.Password
+}
+
+func (p *CustomPlugin) adminBasicAuth() config.AdminBasicAuth {
+	return config.AdminBasicAuth{
+		Username: p.customConfig.AdminBasicAuthUsername,
+		Password: p.customConfig.AdminBasicAuthPassword,
+	}
 }
 
 func (p *CustomPlugin) Start(
@@ -223,11 +242,12 @@ func (p *CustomPlugin) Stop(ctx context.Context) error {
 }
 
 func (p *CustomPlugin) readFromAdminConfigs(ctx context.Context) error {
-	cfgs, err := config.ListAdminProjectConfigsByType(
+	cfgs, err := config.ListAdminProjectConfigsByTypeWithAuth(
 		ctx,
 		p.customConfig.AdminBaseURL,
 		p.customConfig.AdminTimeoutSecond,
 		"custom",
+		p.adminBasicAuth(),
 	)
 	if err != nil {
 		return err
@@ -435,10 +455,11 @@ func splitRuleKeywords(raw string) []string {
 }
 
 func (p *CustomPlugin) applyModelRuntimeConfig(ctx context.Context) error {
-	modelCfg, err := config.LoadModelRuntimeConfig(
+	modelCfg, err := config.LoadModelRuntimeConfigWithAuth(
 		ctx,
 		p.customConfig.AdminBaseURL,
 		p.customConfig.AdminTimeoutSecond,
+		p.adminBasicAuth(),
 	)
 	if err != nil {
 		return err

--- a/complik/plugins/compliance/detector/safety/plugin.go
+++ b/complik/plugins/compliance/detector/safety/plugin.go
@@ -65,13 +65,15 @@ func (p *SafetyPlugin) Type() string {
 }
 
 type SafetyConfig struct {
-	MaxWorkers         int    `json:"maxWorkers"`
-	APIKey             string `json:"apiKey"`
-	APIBase            string `json:"apiBase"`
-	APIPath            string `json:"apiPath"`
-	Model              string `json:"model"`
-	AdminBaseURL       string `json:"adminBaseURL"`
-	AdminTimeoutSecond int    `json:"adminTimeoutSecond"`
+	MaxWorkers             int    `json:"maxWorkers"`
+	APIKey                 string `json:"apiKey"`
+	APIBase                string `json:"apiBase"`
+	APIPath                string `json:"apiPath"`
+	Model                  string `json:"model"`
+	AdminBaseURL           string `json:"adminBaseURL"`
+	AdminTimeoutSecond     int    `json:"adminTimeoutSecond"`
+	AdminBasicAuthUsername string `json:"adminBasicAuthUsername"`
+	AdminBasicAuthPassword string `json:"adminBasicAuthPassword"`
 }
 
 func (p *SafetyPlugin) getDefaultConfig() SafetyConfig {
@@ -114,6 +116,7 @@ func (p *SafetyPlugin) loadConfig(ctx context.Context, setting string) error {
 	if safetyConfig.AdminTimeoutSecond > 0 {
 		p.safetyConfig.AdminTimeoutSecond = safetyConfig.AdminTimeoutSecond
 	}
+	p.applyAdminBasicAuthConfig(safetyConfig)
 	if err := p.applyModelRuntimeConfig(ctx); err != nil {
 		return fmt.Errorf("failed to apply model runtime config from admin: %w", err)
 	}
@@ -137,11 +140,28 @@ func (p *SafetyPlugin) loadConfig(ctx context.Context, setting string) error {
 	return nil
 }
 
+func (p *SafetyPlugin) applyAdminBasicAuthConfig(safetyConfig SafetyConfig) {
+	auth := config.ResolveAdminBasicAuth(
+		safetyConfig.AdminBasicAuthUsername,
+		safetyConfig.AdminBasicAuthPassword,
+	)
+	p.safetyConfig.AdminBasicAuthUsername = auth.Username
+	p.safetyConfig.AdminBasicAuthPassword = auth.Password
+}
+
+func (p *SafetyPlugin) adminBasicAuth() config.AdminBasicAuth {
+	return config.AdminBasicAuth{
+		Username: p.safetyConfig.AdminBasicAuthUsername,
+		Password: p.safetyConfig.AdminBasicAuthPassword,
+	}
+}
+
 func (p *SafetyPlugin) applyModelRuntimeConfig(ctx context.Context) error {
-	modelCfg, err := config.LoadModelRuntimeConfig(
+	modelCfg, err := config.LoadModelRuntimeConfigWithAuth(
 		ctx,
 		p.safetyConfig.AdminBaseURL,
 		p.safetyConfig.AdminTimeoutSecond,
+		p.adminBasicAuth(),
 	)
 	if err != nil {
 		return err
@@ -169,11 +189,12 @@ func (p *SafetyPlugin) applyModelRuntimeConfig(ctx context.Context) error {
 }
 
 func (p *SafetyPlugin) applySafetyPromptRules(ctx context.Context) error {
-	cfgs, err := config.ListAdminProjectConfigsByType(
+	cfgs, err := config.ListAdminProjectConfigsByTypeWithAuth(
 		ctx,
 		p.safetyConfig.AdminBaseURL,
 		p.safetyConfig.AdminTimeoutSecond,
 		"safety",
+		p.adminBasicAuth(),
 	)
 	if err != nil {
 		return err

--- a/complik/plugins/handle/admin/reporter/plugin.go
+++ b/complik/plugins/handle/admin/reporter/plugin.go
@@ -55,9 +55,11 @@ type AdminReporterPlugin struct {
 }
 
 type ReporterConfig struct {
-	Region             string `json:"region"`
-	AdminBaseURL       string `json:"adminBaseURL"`
-	AdminTimeoutSecond int    `json:"adminTimeoutSecond"`
+	Region                 string `json:"region"`
+	AdminBaseURL           string `json:"adminBaseURL"`
+	AdminTimeoutSecond     int    `json:"adminTimeoutSecond"`
+	AdminBasicAuthUsername string `json:"adminBasicAuthUsername"`
+	AdminBasicAuthPassword string `json:"adminBasicAuthPassword"`
 }
 
 type complikViolationRequest struct {
@@ -123,6 +125,7 @@ func (p *AdminReporterPlugin) loadConfig(setting string) error {
 	if configFromJSON.AdminTimeoutSecond > 0 {
 		p.reporterConfig.AdminTimeoutSecond = configFromJSON.AdminTimeoutSecond
 	}
+	p.applyAdminBasicAuthConfig(configFromJSON)
 
 	p.log.Info("Admin reporter configuration loaded", logger.Fields{
 		"region":         p.reporterConfig.Region,
@@ -131,6 +134,22 @@ func (p *AdminReporterPlugin) loadConfig(setting string) error {
 	})
 
 	return nil
+}
+
+func (p *AdminReporterPlugin) applyAdminBasicAuthConfig(configFromJSON ReporterConfig) {
+	auth := config.ResolveAdminBasicAuth(
+		configFromJSON.AdminBasicAuthUsername,
+		configFromJSON.AdminBasicAuthPassword,
+	)
+	p.reporterConfig.AdminBasicAuthUsername = auth.Username
+	p.reporterConfig.AdminBasicAuthPassword = auth.Password
+}
+
+func (p *AdminReporterPlugin) adminBasicAuth() config.AdminBasicAuth {
+	return config.AdminBasicAuth{
+		Username: p.reporterConfig.AdminBasicAuthUsername,
+		Password: p.reporterConfig.AdminBasicAuthPassword,
+	}
 }
 
 func (p *AdminReporterPlugin) Start(
@@ -230,7 +249,7 @@ func (p *AdminReporterPlugin) reportViolation(
 	requestCtx, cancel := context.WithTimeout(parentCtx, p.adminTimeout())
 	defer cancel()
 
-	return postJSON(requestCtx, p.adminEndpoint(), requestBody)
+	return postJSON(requestCtx, p.adminEndpoint(), requestBody, p.adminBasicAuth())
 }
 
 func (p *AdminReporterPlugin) adminEndpoint() string {
@@ -279,7 +298,7 @@ func buildComplikRawPayload(result *models.DetectorInfo) map[string]any {
 	}
 }
 
-func postJSON(ctx context.Context, endpoint string, payload any) error {
+func postJSON(ctx context.Context, endpoint string, payload any, auth config.AdminBasicAuth) error {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
@@ -291,6 +310,7 @@ func postJSON(ctx context.Context, endpoint string, payload any) error {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	auth.Apply(req)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/complik/plugins/handle/lark/plugin.go
+++ b/complik/plugins/handle/lark/plugin.go
@@ -58,10 +58,12 @@ func (p *LarkPlugin) Type() string {
 }
 
 type LarkConfig struct {
-	Region             string `json:"region"`
-	Webhook            string `json:"webhook"`
-	AdminBaseURL       string `json:"adminBaseURL"`
-	AdminTimeoutSecond int    `json:"adminTimeoutSecond"`
+	Region                 string `json:"region"`
+	Webhook                string `json:"webhook"`
+	AdminBaseURL           string `json:"adminBaseURL"`
+	AdminTimeoutSecond     int    `json:"adminTimeoutSecond"`
+	AdminBasicAuthUsername string `json:"adminBasicAuthUsername"`
+	AdminBasicAuthPassword string `json:"adminBasicAuthPassword"`
 }
 
 func (p *LarkPlugin) getDefaultConfig() LarkConfig {
@@ -103,6 +105,7 @@ func (p *LarkPlugin) loadConfig(ctx context.Context, setting string) error {
 	if configFromJSON.AdminTimeoutSecond > 0 {
 		p.larkConfig.AdminTimeoutSecond = configFromJSON.AdminTimeoutSecond
 	}
+	p.applyAdminBasicAuthConfig(configFromJSON)
 	if err := p.applyNotificationsRuntimeConfig(ctx); err != nil {
 		return fmt.Errorf("failed to apply notifications runtime config from admin: %w", err)
 	}
@@ -113,11 +116,28 @@ func (p *LarkPlugin) loadConfig(ctx context.Context, setting string) error {
 	return nil
 }
 
+func (p *LarkPlugin) applyAdminBasicAuthConfig(configFromJSON LarkConfig) {
+	auth := config.ResolveAdminBasicAuth(
+		configFromJSON.AdminBasicAuthUsername,
+		configFromJSON.AdminBasicAuthPassword,
+	)
+	p.larkConfig.AdminBasicAuthUsername = auth.Username
+	p.larkConfig.AdminBasicAuthPassword = auth.Password
+}
+
+func (p *LarkPlugin) adminBasicAuth() config.AdminBasicAuth {
+	return config.AdminBasicAuth{
+		Username: p.larkConfig.AdminBasicAuthUsername,
+		Password: p.larkConfig.AdminBasicAuthPassword,
+	}
+}
+
 func (p *LarkPlugin) applyNotificationsRuntimeConfig(ctx context.Context) error {
-	runtimeCfg, err := config.LoadNotificationsRuntimeConfig(
+	runtimeCfg, err := config.LoadNotificationsRuntimeConfigWithAuth(
 		ctx,
 		p.larkConfig.AdminBaseURL,
 		p.larkConfig.AdminTimeoutSecond,
+		p.adminBasicAuth(),
 	)
 	if err != nil {
 		return err

--- a/procscan/config.yaml
+++ b/procscan/config.yaml
@@ -21,3 +21,6 @@ notifications:
   admin:
     base_url: "http://sealos-complik-admin:8080"
     timeout: "10s"
+    basic_auth:
+      username: "${ADMIN_BASIC_AUTH_USERNAME}"
+      password: "${ADMIN_BASIC_AUTH_PASSWORD}"

--- a/procscan/deploy/manifests/configmap.yaml
+++ b/procscan/deploy/manifests/configmap.yaml
@@ -20,6 +20,9 @@ data:
       admin:
         base_url: "http://sealos-complik-admin:8080"
         timeout: "10s"
+        basic_auth:
+          username: "${ADMIN_BASIC_AUTH_USERNAME}"
+          password: "${ADMIN_BASIC_AUTH_PASSWORD}"
 
     metrics:
       enabled: false

--- a/procscan/deploy/manifests/daemonset.yaml
+++ b/procscan/deploy/manifests/daemonset.yaml
@@ -35,6 +35,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: ADMIN_BASIC_AUTH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: sealos-complik-admin-auth
+                  key: username
+            - name: ADMIN_BASIC_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sealos-complik-admin-auth
+                  key: password
           securityContext:
             privileged: true
             runAsUser: 0

--- a/procscan/internal/adminauth/auth.go
+++ b/procscan/internal/adminauth/auth.go
@@ -1,0 +1,61 @@
+// Copyright 2025 CompliK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adminauth
+
+import (
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	UsernameEnv = "ADMIN_BASIC_AUTH_USERNAME"
+	PasswordEnv = "ADMIN_BASIC_AUTH_PASSWORD"
+)
+
+type BasicAuth struct {
+	Username string
+	Password string
+}
+
+func FromValues(username, password string) BasicAuth {
+	resolvedUsername := resolveValue(username)
+	resolvedPassword := resolveValue(password)
+	if resolvedUsername == "" {
+		resolvedUsername = strings.TrimSpace(os.Getenv(UsernameEnv))
+	}
+	if resolvedPassword == "" {
+		resolvedPassword = strings.TrimSpace(os.Getenv(PasswordEnv))
+	}
+	return BasicAuth{
+		Username: resolvedUsername,
+		Password: resolvedPassword,
+	}
+}
+
+func (a BasicAuth) Apply(req *http.Request) {
+	if req == nil || strings.TrimSpace(a.Username) == "" || strings.TrimSpace(a.Password) == "" {
+		return
+	}
+	req.SetBasicAuth(a.Username, a.Password)
+}
+
+func resolveValue(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if strings.HasPrefix(trimmed, "${") && strings.HasSuffix(trimmed, "}") {
+		return strings.TrimSpace(os.Getenv(strings.TrimSuffix(strings.TrimPrefix(trimmed, "${"), "}")))
+	}
+	return trimmed
+}

--- a/procscan/internal/config/loader.go
+++ b/procscan/internal/config/loader.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bearslyricattack/CompliK/procscan/internal/adminauth"
 	"github.com/bearslyricattack/CompliK/procscan/pkg/models"
 	"gopkg.in/yaml.v3"
 )
@@ -99,8 +100,12 @@ func (l *Loader) loadAdminConfig(config *models.Config) error {
 	if adminBaseURL == "" {
 		return fmt.Errorf("notifications.admin.base_url is required")
 	}
+	auth := adminauth.FromValues(
+		config.Notifications.Admin.BasicAuth.Username,
+		config.Notifications.Admin.BasicAuth.Password,
+	)
 
-	notifications, err := l.loadRemoteNotificationsConfig(adminBaseURL, config.Notifications.Admin.Timeout)
+	notifications, err := l.loadRemoteNotificationsConfig(adminBaseURL, config.Notifications.Admin.Timeout, auth)
 	if err != nil {
 		return fmt.Errorf("load notifications config from admin: %w", err)
 	}
@@ -113,7 +118,7 @@ func (l *Loader) loadAdminConfig(config *models.Config) error {
 	config.Notifications.Region = strings.TrimSpace(*notifications.Region)
 	config.Notifications.Lark.Webhook = strings.TrimSpace(*notifications.Webhook)
 
-	rules, err := l.loadRemoteRulesConfig(adminBaseURL, config.Notifications.Admin.Timeout)
+	rules, err := l.loadRemoteRulesConfig(adminBaseURL, config.Notifications.Admin.Timeout, auth)
 	if err != nil {
 		return fmt.Errorf("load detection rules config from admin: %w", err)
 	}
@@ -122,25 +127,45 @@ func (l *Loader) loadAdminConfig(config *models.Config) error {
 	return nil
 }
 
-func (l *Loader) loadRemoteNotificationsConfig(adminBaseURL string, timeout time.Duration) (*remoteNotificationsConfig, error) {
+func (l *Loader) loadRemoteNotificationsConfig(
+	adminBaseURL string,
+	timeout time.Duration,
+	auth adminauth.BasicAuth,
+) (*remoteNotificationsConfig, error) {
 	var config remoteNotificationsConfig
-	if err := l.loadRemoteConfigValue(adminBaseURL, timeout, procscanNotificationsConfigType, &config); err != nil {
+	if err := l.loadRemoteConfigValue(adminBaseURL, timeout, procscanNotificationsConfigType, &config, auth); err != nil {
 		return nil, err
 	}
 	return &config, nil
 }
 
-func (l *Loader) loadRemoteRulesConfig(adminBaseURL string, timeout time.Duration) (*models.DetectionRules, error) {
+func (l *Loader) loadRemoteRulesConfig(
+	adminBaseURL string,
+	timeout time.Duration,
+	auth adminauth.BasicAuth,
+) (*models.DetectionRules, error) {
 	var rules models.DetectionRules
-	if err := l.loadRemoteConfigValue(adminBaseURL, timeout, procscanRulesConfigType, &rules); err != nil {
+	if err := l.loadRemoteConfigValue(adminBaseURL, timeout, procscanRulesConfigType, &rules, auth); err != nil {
 		return nil, err
 	}
 	return &rules, nil
 }
 
-func (l *Loader) loadRemoteConfigValue(adminBaseURL string, timeout time.Duration, configType string, target any) error {
+func (l *Loader) loadRemoteConfigValue(
+	adminBaseURL string,
+	timeout time.Duration,
+	configType string,
+	target any,
+	auth adminauth.BasicAuth,
+) error {
 	endpoint := strings.TrimRight(adminBaseURL, "/") + "/api/configs/type/" + url.PathEscape(configType)
-	resp, err := adminClient(timeout).Get(endpoint)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("create %s request: %w", configType, err)
+	}
+	auth.Apply(req)
+
+	resp, err := adminClient(timeout).Do(req)
 	if err != nil {
 		return fmt.Errorf("request %s: %w", configType, err)
 	}

--- a/procscan/internal/core/scanner/admin_reporter.go
+++ b/procscan/internal/core/scanner/admin_reporter.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bearslyricattack/CompliK/procscan/internal/adminauth"
 	legacy "github.com/bearslyricattack/CompliK/procscan/pkg/logger/legacy"
 	"github.com/bearslyricattack/CompliK/procscan/pkg/models"
 )
@@ -90,7 +91,7 @@ func (s *Scanner) reportProcscanViolation(endpoint string, processInfo *models.P
 	ctx, cancel := context.WithTimeout(context.Background(), s.adminTimeout())
 	defer cancel()
 
-	return postJSON(ctx, endpoint, payload)
+	return postJSON(ctx, endpoint, payload, s.adminBasicAuth())
 }
 
 func (s *Scanner) adminEndpoint() (string, bool) {
@@ -114,7 +115,17 @@ func (s *Scanner) adminTimeout() time.Duration {
 	return defaultAdminTimeout
 }
 
-func postJSON(ctx context.Context, endpoint string, payload any) error {
+func (s *Scanner) adminBasicAuth() adminauth.BasicAuth {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return adminauth.FromValues(
+		s.config.Notifications.Admin.BasicAuth.Username,
+		s.config.Notifications.Admin.BasicAuth.Password,
+	)
+}
+
+func postJSON(ctx context.Context, endpoint string, payload any, auth adminauth.BasicAuth) error {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
@@ -125,6 +136,7 @@ func postJSON(ctx context.Context, endpoint string, payload any) error {
 		return fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	auth.Apply(req)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/procscan/pkg/models/models.go
+++ b/procscan/pkg/models/models.go
@@ -47,8 +47,14 @@ type LarkNotificationConfig struct {
 
 // AdminNotificationConfig contains configuration for the admin API.
 type AdminNotificationConfig struct {
-	BaseURL string        `yaml:"base_url"`
-	Timeout time.Duration `yaml:"timeout"`
+	BaseURL   string               `yaml:"base_url"`
+	Timeout   time.Duration        `yaml:"timeout"`
+	BasicAuth AdminBasicAuthConfig `yaml:"basic_auth"`
+}
+
+type AdminBasicAuthConfig struct {
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
 }
 
 // NotificationsConfig aggregates all notification channels


### PR DESCRIPTION
## What

Add Basic Auth support for CompliK and Procscan admin requests.

## Changes

- Add admin Basic Auth helpers
- Attach Basic Auth header to CompliK admin config and reporter requests
- Attach Basic Auth header to Procscan config and reporter requests
- Wire Basic Auth credentials through config and deploy manifests
- Update Helm values and templates for Basic Auth secret injection
