### PR TITLE
fix(admin): correct ban status and compliance review output

### DIFF
--- a/complik/plugins/compliance/detector/utils/reviewer.go
+++ b/complik/plugins/compliance/detector/utils/reviewer.go
@@ -173,9 +173,9 @@ func (r *ContentReviewer) buildSafetyPromptFromRules(
 	return fmt.Sprintf(`# Role: Content Analysis and Compliance Checker
 
 # Goal:
-1. Provide a brief one-sentence description of the webpage content or purpose.
-2. Extract up to 5 keywords relevant to the webpage.
-3. Determine whether the webpage contains illegal or non-compliant content according to the safety rules below.
+1. Provide an accurate one-sentence description of the webpage's visible content, service, product, or purpose.
+2. Extract up to 5 English matched keywords or evidence phrases that triggered the safety rules.
+3. Determine whether the webpage contains illegal or non-compliant content according to the safety rules below, and identify the exact violating content locations and evidence.
 
 # Safety Rules:
 %s
@@ -184,9 +184,9 @@ func (r *ContentReviewer) buildSafetyPromptFromRules(
 I am providing you with both a webpage screenshot and HTML code. Please analyze both sources comprehensively. Some content may be more obvious in the screenshot, while other content may need to be analyzed from the HTML code.
 If the page shows 404 errors, various errors, blank pages, or missing resources, it should be considered compliant.
 Output language requirements:
-- description must be Simplified Chinese.
-- keywords must be English keywords.
-- compliance.explanation must be Simplified Chinese and should state the violated category and concrete evidence.
+- description must be Simplified Chinese and must precisely describe the webpage content, business, product, or function.
+- keywords must be English matched risk keywords or evidence phrases found in the screenshot or HTML. Use an empty array when no rule is matched.
+- compliance.explanation must be Simplified Chinese and should state the violated category, exact matched text, UI location or HTML evidence, and why that evidence violates the rules.
 
 # HTML Code Excerpt:
 %s
@@ -195,11 +195,11 @@ Output language requirements:
 Please output strictly in the following JSON format without any additional explanation or text:
 
 {
-  "description": "<简体中文网页描述>",
-  "keywords": ["<keyword1>", "<keyword2>", "<keyword3>", "<keyword4>", "<keyword5>"],
+  "description": "<简体中文网页内容精准描述>",
+  "keywords": ["<matched_keyword1>", "<matched_keyword2>", "<matched_keyword3>", "<matched_keyword4>", "<matched_keyword5>"],
   "compliance": {
     "is_illegal": "<Yes/No>",
-    "explanation": "<简体中文违规依据，说明违规类型、命中内容和具体证据>"
+    "explanation": "<简体中文违规依据，说明违规类型、具体违规位置、命中文案或HTML证据，以及违规原因>"
   }
 }`, strings.TrimSpace(safetyPrompt), htmlBlock)
 }
@@ -208,16 +208,16 @@ func (r *ContentReviewer) buildPrompt(htmlContent string) string {
 	return `# Role: Content Analysis and Compliance Checker
 
 # Goal:
-1. Provide a brief one-sentence description of the given webpage content or purpose.
-2. Extract several keywords relevant to the webpage.
-3. Determine whether the webpage contains content that violates Chinese laws and regulations, particularly in the following categories: pornography, political sensitivity, prohibited items, gambling, cult activities, violence/terrorism, fraud, and infringement.
+1. Provide an accurate one-sentence description of the given webpage's visible content, service, product, or purpose.
+2. Extract up to 5 English matched keywords or evidence phrases that indicate risk.
+3. Determine whether the webpage contains content that violates Chinese laws and regulations, particularly in the following categories: pornography, political sensitivity, prohibited items, gambling, cult activities, violence/terrorism, fraud, and infringement, and identify the exact violating content locations and evidence.
 
 # Instructions:
-1. **Content Description**: Based on the HTML file and webpage screenshot, generate a one-sentence summary describing the main content or purpose of the webpage.
+1. **Content Description**: Based on the HTML file and webpage screenshot, generate a precise one-sentence summary describing the webpage's visible content, business, product, or function. Include the platform name, service type, key functions, and payment or transaction method when they are visible.
 
-2. **Keyword Extraction**: Extract up to 5 keywords most relevant to the webpage content.
+2. **Matched Keyword Extraction**: Extract up to 5 English keywords or short evidence phrases that directly indicate the matched risk. Prefer exact visible text, button text, titles, navigation labels, payment words, action words, HTML text, or other phrases that support the compliance decision.
 
-3. **Compliance Assessment**: Analyze the webpage content to determine if it contains the following illegal or non-compliant content, and provide a brief explanation.
+3. **Compliance Assessment**: Analyze the webpage content to determine if it contains the following illegal or non-compliant content, and provide a concrete explanation with location and evidence.
    - **Pornographic Content**: Are there any sexually explicit images, text, or videos?
    - **Political Sensitivity**: Is there politically sensitive information or criticism of the Chinese government?
    - **Prohibited Items**: Are there any items, behaviors, or services prohibited by Chinese law?
@@ -235,9 +235,9 @@ Pay special attention to social platforms like Weibo, WeChat, Douyin, Kuaishou, 
 ## Special Reminder
 If the page shows 404 errors, various errors, blank pages, or missing resources, it should be considered compliant.
 Output language requirements:
-- description must be Simplified Chinese.
-- keywords must be English keywords.
-- compliance.explanation must be Simplified Chinese and should state the violated category and concrete evidence.
+- description must be Simplified Chinese and must precisely describe the webpage content, business, product, or function.
+- keywords must be English matched risk keywords or evidence phrases found in the screenshot or HTML. Use an empty array when no risk is matched.
+- compliance.explanation must be Simplified Chinese and should state the violated category, exact matched text, UI location or HTML evidence, and why that evidence violates the rules.
 
 # HTML Code Excerpt:
 ` + "```html\n" + htmlContent + "\n```" + `
@@ -246,11 +246,11 @@ Output language requirements:
 Please output strictly in the following JSON format without any additional explanation or text:
 
 {
-  "description": "<简体中文网页描述>",
-  "keywords": ["<keyword1>", "<keyword2>", "<keyword3>", "<keyword4>", "<keyword5>"],
+  "description": "<简体中文网页内容精准描述>",
+  "keywords": ["<matched_keyword1>", "<matched_keyword2>", "<matched_keyword3>", "<matched_keyword4>", "<matched_keyword5>"],
   "compliance": {
     "is_illegal": "<Yes/No>",
-    "explanation": "<简体中文违规依据，说明违规类型、命中内容和具体证据>"
+    "explanation": "<简体中文违规依据，说明违规类型、具体违规位置、命中文案或HTML证据，以及违规原因>"
   }
 }`
 }
@@ -313,14 +313,14 @@ Conduct a comprehensive analysis of the provided webpage content, focusing on de
 # Analysis Requirements:
 
 ## 1. Content Description
-- Based on HTML code analysis, provide a one-sentence concise summary of the webpage's main content or purpose
-- The description should be accurate, objective, and no more than 50 characters
+- Based on HTML code and screenshot analysis, provide a one-sentence concise summary of the webpage's visible content, business, product, or function
+- The description should be accurate, objective, and no more than 80 Chinese characters
 - The description must be written in Simplified Chinese
 
-## 2. Keyword Extraction
-- Extract keywords that best represent the webpage content
+## 2. Matched Keyword Extraction
+- Extract matched keywords or short evidence phrases that directly hit the custom rules
 - Output keywords as a JSON array of English strings, up to 5 items
-- Keywords should accurately reflect the core content of the webpage
+- Keywords should prefer exact matched words, visible text, button text, titles, navigation labels, payment words, action words, HTML text, or other evidence phrases
 
 ## 3. Custom Rule Detection
 Please strictly detect according to the following custom rules:
@@ -339,27 +339,27 @@ Please strictly detect according to the following custom rules:
 I am providing you with both a webpage screenshot and HTML code. Please analyze both sources comprehensively. Some content may be more obvious in the screenshot, while other content may need to be analyzed from the HTML code. Stay vigilant; even seemingly normal websites may hide non-compliant content in the code.
 If the page shows access errors, is blank, or resources do not exist, it should be considered compliant.
 Output language requirements:
-- description must be Simplified Chinese.
-- keywords must be English keywords.
-- compliance.explanation must be Simplified Chinese and should state the matched custom rule type, matched keywords, and concrete evidence.
+- description must be Simplified Chinese and must precisely describe the webpage content, business, product, or function.
+- keywords must be English matched risk keywords or evidence phrases found in the screenshot or HTML. Use an empty array when no custom rule is matched.
+- compliance.explanation must be Simplified Chinese and should state the matched custom rule type, exact matched text, UI location or HTML evidence, and why that evidence violates the custom rule.
 
 # Output Requirements:
 Please output strictly in the following JSON format without any additional explanation or text:
 
 {
-  "description": "<简体中文网页描述>",
-  "keywords": ["<keyword1>", "<keyword2>", "<keyword3>", "<keyword4>", "<keyword5>"],
+  "description": "<简体中文网页内容精准描述>",
+  "keywords": ["<matched_keyword1>", "<matched_keyword2>", "<matched_keyword3>", "<matched_keyword4>", "<matched_keyword5>"],
   "compliance": {
     "is_illegal": "<Yes/No>",
-    "explanation": "<简体中文违规依据，说明命中的自定义规则类型、关键词和具体证据>"
+    "explanation": "<简体中文违规依据，说明命中的自定义规则类型、具体违规位置、命中文案或HTML证据，以及违规原因>"
   }
 }
 
 Notes:
 - compliance.is_illegal: Yes indicates non-compliant content found, No indicates compliant content
-- keywords: Up to 5 English keywords as a JSON array
-- description: Concise one-sentence Simplified Chinese description
-- compliance.explanation: Simplified Chinese explanation of matched rule types, matched keywords, and evidence`, rulesDescription, htmlContent)
+- keywords: Up to 5 English matched risk keywords or evidence phrases as a JSON array
+- description: Precise one-sentence Simplified Chinese webpage content description
+- compliance.explanation: Simplified Chinese explanation of matched rule types, exact locations, matched text, HTML or screenshot evidence, and violation reason`, rulesDescription, htmlContent)
 }
 
 func (r *ContentReviewer) callAPI(
@@ -542,7 +542,7 @@ var ReviewResultSchema = map[string]any{
 			"properties": map[string]any{
 				"description": map[string]any{
 					"type":        "string",
-					"description": "Simplified Chinese one-sentence description of webpage content or purpose",
+					"description": "Precise Simplified Chinese one-sentence description of webpage content, business, product, or function",
 				},
 				"keywords": map[string]any{
 					"type": "array",
@@ -550,7 +550,7 @@ var ReviewResultSchema = map[string]any{
 						"type": "string",
 					},
 					"maxItems":    5,
-					"description": "English keywords most relevant to webpage content, up to 5",
+					"description": "English matched risk keywords or evidence phrases found in the screenshot or HTML, up to 5",
 				},
 				"compliance": map[string]any{
 					"type": "object",
@@ -562,7 +562,7 @@ var ReviewResultSchema = map[string]any{
 						},
 						"explanation": map[string]any{
 							"type":        "string",
-							"description": "Simplified Chinese explanation listing violated categories, matched keywords, and concrete evidence",
+							"description": "Simplified Chinese explanation listing violated categories, exact violating locations, matched text, HTML or screenshot evidence, and violation reason",
 						},
 					},
 					"required": []string{

--- a/complik/plugins/compliance/detector/utils/reviewer.go
+++ b/complik/plugins/compliance/detector/utils/reviewer.go
@@ -183,6 +183,10 @@ func (r *ContentReviewer) buildSafetyPromptFromRules(
 # Important Notes:
 I am providing you with both a webpage screenshot and HTML code. Please analyze both sources comprehensively. Some content may be more obvious in the screenshot, while other content may need to be analyzed from the HTML code.
 If the page shows 404 errors, various errors, blank pages, or missing resources, it should be considered compliant.
+Output language requirements:
+- description must be Simplified Chinese.
+- keywords must be English keywords.
+- compliance.explanation must be Simplified Chinese and should state the violated category and concrete evidence.
 
 # HTML Code Excerpt:
 %s
@@ -191,11 +195,11 @@ If the page shows 404 errors, various errors, blank pages, or missing resources,
 Please output strictly in the following JSON format without any additional explanation or text:
 
 {
-  "description": "<Generated webpage description>",
+  "description": "<简体中文网页描述>",
   "keywords": ["<keyword1>", "<keyword2>", "<keyword3>", "<keyword4>", "<keyword5>"],
   "compliance": {
     "is_illegal": "<Yes/No>",
-    "explanation": "<Brief explanation listing specific violated categories and evidence>"
+    "explanation": "<简体中文违规依据，说明违规类型、命中内容和具体证据>"
   }
 }`, strings.TrimSpace(safetyPrompt), htmlBlock)
 }
@@ -230,6 +234,10 @@ Pay special attention to social platforms like Weibo, WeChat, Douyin, Kuaishou, 
 
 ## Special Reminder
 If the page shows 404 errors, various errors, blank pages, or missing resources, it should be considered compliant.
+Output language requirements:
+- description must be Simplified Chinese.
+- keywords must be English keywords.
+- compliance.explanation must be Simplified Chinese and should state the violated category and concrete evidence.
 
 # HTML Code Excerpt:
 ` + "```html\n" + htmlContent + "\n```" + `
@@ -238,11 +246,11 @@ If the page shows 404 errors, various errors, blank pages, or missing resources,
 Please output strictly in the following JSON format without any additional explanation or text:
 
 {
-  "description": "<Generated webpage description>",
+  "description": "<简体中文网页描述>",
   "keywords": ["<keyword1>", "<keyword2>", "<keyword3>", "<keyword4>", "<keyword5>"],
   "compliance": {
     "is_illegal": "<Yes/No>",
-    "explanation": "<Brief explanation listing specific violated categories and evidence>"
+    "explanation": "<简体中文违规依据，说明违规类型、命中内容和具体证据>"
   }
 }`
 }
@@ -307,10 +315,11 @@ Conduct a comprehensive analysis of the provided webpage content, focusing on de
 ## 1. Content Description
 - Based on HTML code analysis, provide a one-sentence concise summary of the webpage's main content or purpose
 - The description should be accurate, objective, and no more than 50 characters
+- The description must be written in Simplified Chinese
 
 ## 2. Keyword Extraction
 - Extract keywords that best represent the webpage content
-- Multiple keywords separated by commas, up to 5
+- Output keywords as a JSON array of English strings, up to 5 items
 - Keywords should accurately reflect the core content of the webpage
 
 ## 3. Custom Rule Detection
@@ -329,20 +338,28 @@ Please strictly detect according to the following custom rules:
 # Important Notes:
 I am providing you with both a webpage screenshot and HTML code. Please analyze both sources comprehensively. Some content may be more obvious in the screenshot, while other content may need to be analyzed from the HTML code. Stay vigilant; even seemingly normal websites may hide non-compliant content in the code.
 If the page shows access errors, is blank, or resources do not exist, it should be considered compliant.
+Output language requirements:
+- description must be Simplified Chinese.
+- keywords must be English keywords.
+- compliance.explanation must be Simplified Chinese and should state the matched custom rule type, matched keywords, and concrete evidence.
 
 # Output Requirements:
 Please output strictly in the following JSON format without any additional explanation or text:
 
 {
-  "is_compliant": true,
-  "keywords": "keyword1,keyword2,keyword3",
-  "description": "One-sentence description of webpage content"
+  "description": "<简体中文网页描述>",
+  "keywords": ["<keyword1>", "<keyword2>", "<keyword3>", "<keyword4>", "<keyword5>"],
+  "compliance": {
+    "is_illegal": "<Yes/No>",
+    "explanation": "<简体中文违规依据，说明命中的自定义规则类型、关键词和具体证据>"
+  }
 }
 
 Notes:
-- is_compliant: true indicates compliant content, false indicates non-compliant content found
-- keywords: Multiple keywords separated by commas
-- description: Concise one-sentence description`, rulesDescription, htmlContent)
+- compliance.is_illegal: Yes indicates non-compliant content found, No indicates compliant content
+- keywords: Up to 5 English keywords as a JSON array
+- description: Concise one-sentence Simplified Chinese description
+- compliance.explanation: Simplified Chinese explanation of matched rule types, matched keywords, and evidence`, rulesDescription, htmlContent)
 }
 
 func (r *ContentReviewer) callAPI(
@@ -525,7 +542,7 @@ var ReviewResultSchema = map[string]any{
 			"properties": map[string]any{
 				"description": map[string]any{
 					"type":        "string",
-					"description": "Brief description of webpage content, one sentence summarizing the main content or purpose",
+					"description": "Simplified Chinese one-sentence description of webpage content or purpose",
 				},
 				"keywords": map[string]any{
 					"type": "array",
@@ -533,7 +550,7 @@ var ReviewResultSchema = map[string]any{
 						"type": "string",
 					},
 					"maxItems":    5,
-					"description": "Keywords most relevant to webpage content, up to 5",
+					"description": "English keywords most relevant to webpage content, up to 5",
 				},
 				"compliance": map[string]any{
 					"type": "object",
@@ -545,7 +562,7 @@ var ReviewResultSchema = map[string]any{
 						},
 						"explanation": map[string]any{
 							"type":        "string",
-							"description": "Brief explanation listing specific violated categories and evidence",
+							"description": "Simplified Chinese explanation listing violated categories, matched keywords, and concrete evidence",
 						},
 					},
 					"required": []string{

--- a/sealos-complik-admin/internal/modules/ban/repository.go
+++ b/sealos-complik-admin/internal/modules/ban/repository.go
@@ -7,8 +7,21 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	banStatusActionBan   = "ban"
+	banStatusActionUnban = "unban"
+)
+
 type Repository struct {
 	db *gorm.DB
+}
+
+type banStatusAction struct {
+	Kind         string
+	ID           uint64
+	CreatedAt    time.Time
+	BanStartTime *time.Time
+	BanEndTime   *time.Time
 }
 
 func NewRepository(db *gorm.DB) *Repository {
@@ -65,21 +78,58 @@ func (r *Repository) DeleteBanByID(ctx context.Context, id uint64) error {
 	return nil
 }
 
-// HasActiveBan reports whether the given namespace currently has any active ban records.
+// HasActiveBan reports whether the latest ban or unban action leaves the namespace banned.
 func (r *Repository) HasActiveBan(
 	ctx context.Context,
 	namespace string,
 	now time.Time,
 ) (bool, error) {
-	var count int64
-	if err := r.db.WithContext(ctx).
-		Model(&Ban{}).
-		Where("namespace = ?", namespace).
-		Where("ban_start_time <= ?", now).
-		Where("ban_end_time IS NULL OR ban_end_time >= ?", now).
-		Count(&count).Error; err != nil {
+	action, err := r.getLatestBanStatusAction(ctx, namespace)
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return false, nil
+		}
 		return false, err
 	}
 
-	return count > 0, nil
+	if action.Kind != banStatusActionBan || action.BanStartTime == nil {
+		return false, nil
+	}
+
+	if action.BanStartTime.After(now) {
+		return false, nil
+	}
+
+	return action.BanEndTime == nil || !action.BanEndTime.Before(now), nil
+}
+
+func (r *Repository) getLatestBanStatusAction(
+	ctx context.Context,
+	namespace string,
+) (*banStatusAction, error) {
+	var action banStatusAction
+	if err := r.db.WithContext(ctx).
+		Raw(`
+SELECT kind, id, created_at, ban_start_time, ban_end_time
+FROM (
+	SELECT ? AS kind, id, created_at, ban_start_time, ban_end_time
+	FROM bans
+	WHERE namespace = ?
+	UNION ALL
+	SELECT ? AS kind, id, created_at, NULL AS ban_start_time, NULL AS ban_end_time
+	FROM unbans
+	WHERE namespace = ?
+) AS actions
+ORDER BY created_at DESC, id DESC
+LIMIT 1
+`, banStatusActionBan, namespace, banStatusActionUnban, namespace).
+		Scan(&action).Error; err != nil {
+		return nil, err
+	}
+
+	if action.ID == 0 && action.Kind == "" {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	return &action, nil
 }

--- a/sealos-complik-admin/internal/modules/ban/repository.go
+++ b/sealos-complik-admin/internal/modules/ban/repository.go
@@ -17,11 +17,9 @@ type Repository struct {
 }
 
 type banStatusAction struct {
-	Kind         string
-	ID           uint64
-	CreatedAt    time.Time
-	BanStartTime *time.Time
-	BanEndTime   *time.Time
+	Kind      string
+	ID        uint64
+	CreatedAt time.Time
 }
 
 func NewRepository(db *gorm.DB) *Repository {
@@ -92,15 +90,7 @@ func (r *Repository) HasActiveBan(
 		return false, err
 	}
 
-	if action.Kind != banStatusActionBan || action.BanStartTime == nil {
-		return false, nil
-	}
-
-	if action.BanStartTime.After(now) {
-		return false, nil
-	}
-
-	return action.BanEndTime == nil || !action.BanEndTime.Before(now), nil
+	return action.Kind == banStatusActionBan, nil
 }
 
 func (r *Repository) getLatestBanStatusAction(
@@ -110,17 +100,17 @@ func (r *Repository) getLatestBanStatusAction(
 	var action banStatusAction
 	if err := r.db.WithContext(ctx).
 		Raw(`
-SELECT kind, id, created_at, ban_start_time, ban_end_time
+SELECT kind, id, created_at
 FROM (
-	SELECT ? AS kind, id, created_at, ban_start_time, ban_end_time
+	SELECT ? AS kind, id, created_at, 0 AS action_rank
 	FROM bans
 	WHERE namespace = ?
 	UNION ALL
-	SELECT ? AS kind, id, created_at, NULL AS ban_start_time, NULL AS ban_end_time
+	SELECT ? AS kind, id, created_at, 1 AS action_rank
 	FROM unbans
 	WHERE namespace = ?
 ) AS actions
-ORDER BY created_at DESC, id DESC
+ORDER BY created_at DESC, action_rank DESC, id DESC
 LIMIT 1
 `, banStatusActionBan, namespace, banStatusActionUnban, namespace).
 		Scan(&action).Error; err != nil {

--- a/sealos-complik-admin/internal/modules/ban/repository.go
+++ b/sealos-complik-admin/internal/modules/ban/repository.go
@@ -76,13 +76,13 @@ func (r *Repository) DeleteBanByID(ctx context.Context, id uint64) error {
 	return nil
 }
 
-// HasActiveBan reports whether the latest ban or unban action leaves the namespace banned.
+// HasActiveBan reports whether active ban actions leave the namespace banned.
 func (r *Repository) HasActiveBan(
 	ctx context.Context,
 	namespace string,
 	now time.Time,
 ) (bool, error) {
-	action, err := r.getLatestBanStatusAction(ctx, namespace)
+	action, err := r.getLatestBanStatusAction(ctx, namespace, now)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return false, nil
@@ -96,23 +96,26 @@ func (r *Repository) HasActiveBan(
 func (r *Repository) getLatestBanStatusAction(
 	ctx context.Context,
 	namespace string,
+	now time.Time,
 ) (*banStatusAction, error) {
 	var action banStatusAction
 	if err := r.db.WithContext(ctx).
 		Raw(`
 SELECT kind, id, created_at
 FROM (
-	SELECT ? AS kind, id, created_at, 0 AS action_rank
-	FROM bans
-	WHERE namespace = ?
-	UNION ALL
-	SELECT ? AS kind, id, created_at, 1 AS action_rank
-	FROM unbans
-	WHERE namespace = ?
+		SELECT ? AS kind, id, created_at, 0 AS action_rank
+		FROM bans
+		WHERE namespace = ?
+			AND ban_start_time <= ?
+			AND (ban_end_time IS NULL OR ban_end_time > ?)
+		UNION ALL
+		SELECT ? AS kind, id, created_at, 1 AS action_rank
+		FROM unbans
+		WHERE namespace = ?
 ) AS actions
 ORDER BY created_at DESC, action_rank DESC, id DESC
 LIMIT 1
-`, banStatusActionBan, namespace, banStatusActionUnban, namespace).
+	`, banStatusActionBan, namespace, now, now, banStatusActionUnban, namespace).
 		Scan(&action).Error; err != nil {
 		return nil, err
 	}

--- a/sealos-complik-admin/web/src/contexts/AppDataContext.tsx
+++ b/sealos-complik-admin/web/src/contexts/AppDataContext.tsx
@@ -104,6 +104,38 @@ function getTimeMs(value: number | null | undefined, fallback: string) {
   return typeof value === "number" && Number.isFinite(value) ? value : toTimestamp(fallback);
 }
 
+const disposalActionRanks = {
+  ban: 0,
+  unban: 1,
+} as const;
+
+function getDisposalActionSequenceStep(bans: BanRecord[], unbans: UnbanRecord[]) {
+  let maxApiId = 0;
+  bans.forEach((item) => {
+    maxApiId = Math.max(maxApiId, item.apiId);
+  });
+  unbans.forEach((item) => {
+    maxApiId = Math.max(maxApiId, item.apiId);
+  });
+
+  return maxApiId + 1;
+}
+
+function getDisposalActionSequence(kind: keyof typeof disposalActionRanks, apiId: number, sequenceStep: number) {
+  return disposalActionRanks[kind] * sequenceStep + apiId;
+}
+
+function getBanEndTimeMs(item: BanRecord) {
+  return item.banEndTime ? getTimeMs(item.banEndTimeMs, item.banEndTime) : undefined;
+}
+
+function isBanInEffect(item: BanRecord, nowMs: number) {
+  const startMs = getTimeMs(item.banStartTimeMs, item.banStartTime);
+  const endMs = getBanEndTimeMs(item);
+
+  return startMs <= nowMs && (endMs === undefined || endMs > nowMs);
+}
+
 function compareNewestFirst(
   a: { sortTime: number; sequence: number },
   b: { sortTime: number; sequence: number },
@@ -128,7 +160,64 @@ type DisposalAction = {
   sequence: number;
 };
 
+type DisposalStatusAction = {
+  namespace: string;
+  kind: keyof typeof disposalActionRanks;
+  apiId: number;
+  sortTime: number;
+};
+
+function isDisposalStatusActionNewer(candidate: DisposalStatusAction, current: DisposalStatusAction) {
+  if (candidate.sortTime !== current.sortTime) {
+    return candidate.sortTime > current.sortTime;
+  }
+
+  const rankDiff = disposalActionRanks[candidate.kind] - disposalActionRanks[current.kind];
+  if (rankDiff !== 0) {
+    return rankDiff > 0;
+  }
+
+  return candidate.apiId > current.apiId;
+}
+
+function recordDisposalStatusAction(
+  latestActions: Map<string, DisposalStatusAction>,
+  action: DisposalStatusAction,
+) {
+  const current = latestActions.get(action.namespace);
+  if (current === undefined || isDisposalStatusActionNewer(action, current)) {
+    latestActions.set(action.namespace, action);
+  }
+}
+
+function buildLatestDisposalStatusActionsByNamespace(bans: BanRecord[], unbans: UnbanRecord[], nowMs: number) {
+  const latestActions = new Map<string, DisposalStatusAction>();
+
+  bans.forEach((item) => {
+    if (isBanInEffect(item, nowMs)) {
+      recordDisposalStatusAction(latestActions, {
+        namespace: item.namespace,
+        kind: "ban",
+        apiId: item.apiId,
+        sortTime: getTimeMs(item.createdAtMs, item.createdAt),
+      });
+    }
+  });
+
+  unbans.forEach((item) => {
+    recordDisposalStatusAction(latestActions, {
+      namespace: item.namespace,
+      kind: "unban",
+      apiId: item.apiId,
+      sortTime: getTimeMs(item.createdAtMs, item.createdAt),
+    });
+  });
+
+  return latestActions;
+}
+
 function buildDisposalActions(bans: BanRecord[], unbans: UnbanRecord[]) {
+  const sequenceStep = getDisposalActionSequenceStep(bans, unbans);
   const actions: DisposalAction[] = [
     ...bans.map((item) => ({
       id: `timeline-${item.id}`,
@@ -139,7 +228,7 @@ function buildDisposalActions(bans: BanRecord[], unbans: UnbanRecord[]) {
       time: item.createdAt,
       tone: "warn" as const,
       sortTime: getTimeMs(item.createdAtMs, item.createdAt),
-      sequence: item.apiId * 2,
+      sequence: getDisposalActionSequence("ban", item.apiId, sequenceStep),
     })),
     ...unbans.map((item) => ({
       id: `timeline-${item.id}`,
@@ -150,28 +239,22 @@ function buildDisposalActions(bans: BanRecord[], unbans: UnbanRecord[]) {
       time: item.createdAt,
       tone: "success" as const,
       sortTime: getTimeMs(item.createdAtMs, item.createdAt),
-      sequence: item.apiId * 2 + 1,
+      sequence: getDisposalActionSequence("unban", item.apiId, sequenceStep),
     })),
   ];
 
   return actions.sort(compareNewestFirst);
 }
 
-function isNamespaceBanned(namespace: string, bans: BanRecord[], unbans: UnbanRecord[]) {
-  const latestAction = buildDisposalActions(
-    bans.filter((item) => item.namespace === namespace),
-    unbans.filter((item) => item.namespace === namespace),
-  )[0];
-
-  return latestAction?.kind === "ban";
-}
-
-function buildStats(violations: ViolationRecord[], bans: BanRecord[], unbans: UnbanRecord[]): StatCardItem[] {
+function buildStats(
+  violations: ViolationRecord[],
+  bans: BanRecord[],
+  unbans: UnbanRecord[],
+  nowMs: number,
+  latestDisposalStatusActions: Map<string, DisposalStatusAction>,
+): StatCardItem[] {
   const violationNamespaces = new Set(violations.map((item) => item.namespace));
-  const actionNamespaces = new Set<string>();
-  bans.forEach((item) => actionNamespaces.add(item.namespace));
-  unbans.forEach((item) => actionNamespaces.add(item.namespace));
-  const todayStart = new Date();
+  const todayStart = new Date(nowMs);
   todayStart.setHours(0, 0, 0, 0);
   const todayStartTime = todayStart.getTime();
 
@@ -179,7 +262,7 @@ function buildStats(violations: ViolationRecord[], bans: BanRecord[], unbans: Un
   const todayActionCount =
     bans.filter((item) => getTimeMs(item.createdAtMs, item.createdAt) >= todayStartTime).length +
     unbans.filter((item) => getTimeMs(item.createdAtMs, item.createdAt) >= todayStartTime).length;
-  const activeBanCount = [...actionNamespaces].filter((namespace) => isNamespaceBanned(namespace, bans, unbans)).length;
+  const activeBanCount = [...latestDisposalStatusActions.values()].filter((action) => action.kind === "ban").length;
 
   return [
     {
@@ -239,6 +322,7 @@ function buildLatestActions(
   unbans: UnbanRecord[],
   commitments: CommitmentRecord[],
 ): ActivityItem[] {
+  const sequenceStep = getDisposalActionSequenceStep(bans, unbans);
   const actions: Array<ActivityItem & { sortTime: number; sequence: number }> = [
     ...bans.map((item) => ({
       id: item.id,
@@ -248,7 +332,7 @@ function buildLatestActions(
       tone: "warn" as const,
       targetPath: "/bans",
       sortTime: getTimeMs(item.createdAtMs, item.createdAt),
-      sequence: item.apiId * 2,
+      sequence: getDisposalActionSequence("ban", item.apiId, sequenceStep),
     })),
     ...unbans.map((item) => ({
       id: item.id,
@@ -258,7 +342,7 @@ function buildLatestActions(
       tone: "success" as const,
       targetPath: "/unbans",
       sortTime: getTimeMs(item.createdAtMs, item.createdAt),
-      sequence: item.apiId * 2 + 1,
+      sequence: getDisposalActionSequence("unban", item.apiId, sequenceStep),
     })),
     ...commitments.map((item) => ({
       id: item.id,
@@ -283,6 +367,7 @@ function buildNamespaceProfiles(
   commitments: CommitmentRecord[],
   bans: BanRecord[],
   unbans: UnbanRecord[],
+  latestDisposalStatusActions: Map<string, DisposalStatusAction>,
 ): NamespaceProfile[] {
   const namespaces = new Set<string>();
   violations.forEach((item) => namespaces.add(item.namespace));
@@ -333,7 +418,7 @@ function buildNamespaceProfiles(
     return {
       namespace,
       violated: namespaceViolations.length > 0,
-      banned: latestDisposalAction?.kind === "ban",
+      banned: latestDisposalStatusActions.get(namespace)?.kind === "ban",
       commitmentUploaded: Boolean(namespaceCommitment),
       lastActionAt,
       commitment: namespaceCommitment
@@ -363,6 +448,7 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
   const [banRecords, setBanRecords] = useState<BanRecord[]>([]);
   const [unbanRecords, setUnbanRecords] = useState<UnbanRecord[]>([]);
   const [violations, setViolations] = useState<ViolationRecord[]>([]);
+  const [nowMs, setNowMs] = useState(() => Date.now());
 
   const refreshAll = useCallback(async () => {
     setIsLoading(true);
@@ -392,6 +478,7 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
       setBanRecords(bans);
       setUnbanRecords(unbans);
       setViolations(violationList);
+      setNowMs(Date.now());
       if (loadErrors.length > 0) {
         setError(loadErrors.join("；"));
       }
@@ -406,15 +493,27 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
     void refreshAll();
   }, [refreshAll]);
 
-  const stats = useMemo(() => buildStats(violations, banRecords, unbanRecords), [banRecords, unbanRecords, violations]);
+  useEffect(() => {
+    const intervalId = window.setInterval(() => setNowMs(Date.now()), 60_000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  const latestDisposalStatusActions = useMemo(
+    () => buildLatestDisposalStatusActionsByNamespace(banRecords, unbanRecords, nowMs),
+    [banRecords, nowMs, unbanRecords],
+  );
+  const stats = useMemo(
+    () => buildStats(violations, banRecords, unbanRecords, nowMs, latestDisposalStatusActions),
+    [banRecords, latestDisposalStatusActions, nowMs, unbanRecords, violations],
+  );
   const latestViolations = useMemo(() => buildLatestViolations(violations), [violations]);
   const latestActions = useMemo(
     () => buildLatestActions(banRecords, unbanRecords, commitmentRecords),
     [banRecords, commitmentRecords, unbanRecords],
   );
   const namespaceProfiles = useMemo(
-    () => buildNamespaceProfiles(violations, commitmentRecords, banRecords, unbanRecords),
-    [banRecords, commitmentRecords, unbanRecords, violations],
+    () => buildNamespaceProfiles(violations, commitmentRecords, banRecords, unbanRecords, latestDisposalStatusActions),
+    [banRecords, commitmentRecords, latestDisposalStatusActions, unbanRecords, violations],
   );
 
   const createConfigRecord = useCallback(

--- a/sealos-complik-admin/web/src/contexts/AppDataContext.tsx
+++ b/sealos-complik-admin/web/src/contexts/AppDataContext.tsx
@@ -100,18 +100,89 @@ function describeBanRecord(item: BanRecord) {
   return details.join("，");
 }
 
+function getTimeMs(value: number | null | undefined, fallback: string) {
+  return typeof value === "number" && Number.isFinite(value) ? value : toTimestamp(fallback);
+}
+
+function compareNewestFirst(
+  a: { sortTime: number; sequence: number },
+  b: { sortTime: number; sequence: number },
+) {
+  const timeDiff = b.sortTime - a.sortTime;
+  if (timeDiff !== 0) {
+    return timeDiff;
+  }
+
+  return b.sequence - a.sequence;
+}
+
+type DisposalAction = {
+  id: string;
+  namespace: string;
+  kind: "ban" | "unban";
+  title: string;
+  description: string;
+  time: string;
+  tone: ActivityItem["tone"];
+  sortTime: number;
+  sequence: number;
+  active: boolean;
+};
+
+function buildDisposalActions(bans: BanRecord[], unbans: UnbanRecord[]) {
+  const actions: DisposalAction[] = [
+    ...bans.map((item) => ({
+      id: `timeline-${item.id}`,
+      namespace: item.namespace,
+      kind: "ban" as const,
+      title: "新增封禁记录",
+      description: describeBanRecord(item),
+      time: item.createdAt,
+      tone: "warn" as const,
+      sortTime: getTimeMs(item.createdAtMs, item.createdAt),
+      sequence: item.apiId * 2,
+      active: item.active,
+    })),
+    ...unbans.map((item) => ({
+      id: `timeline-${item.id}`,
+      namespace: item.namespace,
+      kind: "unban" as const,
+      title: "新增解封记录",
+      description: `操作人 ${item.operatorName}`,
+      time: item.createdAt,
+      tone: "success" as const,
+      sortTime: getTimeMs(item.createdAtMs, item.createdAt),
+      sequence: item.apiId * 2 + 1,
+      active: false,
+    })),
+  ];
+
+  return actions.sort(compareNewestFirst);
+}
+
+function isNamespaceBanned(namespace: string, bans: BanRecord[], unbans: UnbanRecord[]) {
+  const latestAction = buildDisposalActions(
+    bans.filter((item) => item.namespace === namespace),
+    unbans.filter((item) => item.namespace === namespace),
+  )[0];
+
+  return Boolean(latestAction?.kind === "ban" && latestAction.active);
+}
+
 function buildStats(violations: ViolationRecord[], bans: BanRecord[], unbans: UnbanRecord[]): StatCardItem[] {
   const violationNamespaces = new Set(violations.map((item) => item.namespace));
-  const now = Date.now();
+  const actionNamespaces = new Set<string>();
+  bans.forEach((item) => actionNamespaces.add(item.namespace));
+  unbans.forEach((item) => actionNamespaces.add(item.namespace));
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
   const todayStartTime = todayStart.getTime();
 
-  const todayViolationCount = violations.filter((item) => toTimestamp(item.detectedAt) >= todayStartTime).length;
+  const todayViolationCount = violations.filter((item) => getTimeMs(item.detectedAtMs, item.detectedAt) >= todayStartTime).length;
   const todayActionCount =
-    bans.filter((item) => toTimestamp(item.createdAt) >= todayStartTime).length +
-    unbans.filter((item) => toTimestamp(item.createdAt) >= todayStartTime).length;
-  const activeBanCount = bans.filter((item) => item.active && toTimestamp(item.banStartTime) <= now).length;
+    bans.filter((item) => getTimeMs(item.createdAtMs, item.createdAt) >= todayStartTime).length +
+    unbans.filter((item) => getTimeMs(item.createdAtMs, item.createdAt) >= todayStartTime).length;
+  const activeBanCount = [...actionNamespaces].filter((namespace) => isNamespaceBanned(namespace, bans, unbans)).length;
 
   return [
     {
@@ -127,7 +198,7 @@ function buildStats(violations: ViolationRecord[], bans: BanRecord[], unbans: Un
       value: String(activeBanCount),
       delta: `${bans.length} 条封禁记录`,
       tone: "warn",
-      description: "按当前仍处于有效期内的封禁记录统计。",
+      description: "按最新封禁或解封动作后的当前状态统计。",
       targetPath: "/bans",
     },
     {
@@ -151,7 +222,7 @@ function buildStats(violations: ViolationRecord[], bans: BanRecord[], unbans: Un
 
 function buildLatestViolations(violations: ViolationRecord[]): ActivityItem[] {
   return [...violations]
-    .sort((a, b) => toTimestamp(b.detectedAt) - toTimestamp(a.detectedAt))
+    .sort((a, b) => getTimeMs(b.detectedAtMs, b.detectedAt) - getTimeMs(a.detectedAtMs, a.detectedAt))
     .slice(0, 3)
     .map((item) => ({
       id: item.id,
@@ -171,7 +242,7 @@ function buildLatestActions(
   unbans: UnbanRecord[],
   commitments: CommitmentRecord[],
 ): ActivityItem[] {
-  const actions: Array<ActivityItem & { sortTime: number }> = [
+  const actions: Array<ActivityItem & { sortTime: number; sequence: number }> = [
     ...bans.map((item) => ({
       id: item.id,
       namespace: item.namespace,
@@ -179,7 +250,8 @@ function buildLatestActions(
       time: item.createdAt,
       tone: "warn" as const,
       targetPath: "/bans",
-      sortTime: toTimestamp(item.createdAt),
+      sortTime: getTimeMs(item.createdAtMs, item.createdAt),
+      sequence: item.apiId * 2,
     })),
     ...unbans.map((item) => ({
       id: item.id,
@@ -188,7 +260,8 @@ function buildLatestActions(
       time: item.createdAt,
       tone: "success" as const,
       targetPath: "/unbans",
-      sortTime: toTimestamp(item.createdAt),
+      sortTime: getTimeMs(item.createdAtMs, item.createdAt),
+      sequence: item.apiId * 2 + 1,
     })),
     ...commitments.map((item) => ({
       id: item.id,
@@ -197,14 +270,15 @@ function buildLatestActions(
       time: item.updatedAt,
       tone: "info" as const,
       targetPath: "/commitments",
-      sortTime: toTimestamp(item.updatedAt),
+      sortTime: getTimeMs(item.updatedAtMs, item.updatedAt),
+      sequence: getTimeMs(item.updatedAtMs, item.updatedAt),
     })),
   ];
 
   return actions
-    .sort((a, b) => b.sortTime - a.sortTime)
+    .sort(compareNewestFirst)
     .slice(0, 3)
-    .map(({ sortTime: _sortTime, ...item }) => item);
+    .map(({ sortTime: _sortTime, sequence: _sequence, ...item }) => item);
 }
 
 function buildNamespaceProfiles(
@@ -222,40 +296,26 @@ function buildNamespaceProfiles(
   const profiles = [...namespaces].map((namespace) => {
     const namespaceViolations = violations
       .filter((item) => item.namespace === namespace)
-      .sort((a, b) => toTimestamp(b.detectedAt) - toTimestamp(a.detectedAt));
+      .sort((a, b) => getTimeMs(b.detectedAtMs, b.detectedAt) - getTimeMs(a.detectedAtMs, a.detectedAt));
     const namespaceCommitment = commitments.find((item) => item.namespace === namespace);
     const namespaceBans = bans
       .filter((item) => item.namespace === namespace)
-      .sort((a, b) => toTimestamp(b.banStartTime) - toTimestamp(a.banStartTime));
-    const namespaceUnbans = unbans
-      .filter((item) => item.namespace === namespace)
-      .sort((a, b) => toTimestamp(b.createdAt) - toTimestamp(a.createdAt));
+      .sort((a, b) => getTimeMs(b.banStartTimeMs, b.banStartTime) - getTimeMs(a.banStartTimeMs, a.banStartTime));
+    const namespaceUnbans = unbans.filter((item) => item.namespace === namespace);
+    const disposalActions = buildDisposalActions(namespaceBans, namespaceUnbans);
+    const latestDisposalAction = disposalActions[0];
 
-    const timeline: Array<TimelineRecord & { sortTime: number }> = [
+    const timeline: Array<TimelineRecord & { sortTime: number; sequence: number }> = [
       ...namespaceViolations.map((item) => ({
         id: `timeline-${item.id}`,
         title: item.type === "complik" ? "出现内容违规" : "出现进程违规",
         description: summarizeMarkdown(item.description, 72) || "暂无描述",
         time: item.detectedAt,
         tone: getViolationTone(item.type),
-        sortTime: toTimestamp(item.detectedAt),
+        sortTime: getTimeMs(item.detectedAtMs, item.detectedAt),
+        sequence: item.apiId,
       })),
-      ...namespaceBans.map((item) => ({
-        id: `timeline-ban-${item.id}`,
-        title: "新增封禁记录",
-        description: describeBanRecord(item),
-        time: item.createdAt,
-        tone: "warn" as const,
-        sortTime: toTimestamp(item.createdAt),
-      })),
-      ...namespaceUnbans.map((item) => ({
-        id: `timeline-unban-${item.id}`,
-        title: "新增解封记录",
-        description: `操作人 ${item.operatorName}`,
-        time: item.createdAt,
-        tone: "success" as const,
-        sortTime: toTimestamp(item.createdAt),
-      })),
+      ...disposalActions,
       ...(namespaceCommitment
         ? [
             {
@@ -264,18 +324,19 @@ function buildNamespaceProfiles(
               description: `${namespaceCommitment.fileName}`,
               time: namespaceCommitment.updatedAt,
               tone: "info" as const,
-              sortTime: toTimestamp(namespaceCommitment.updatedAt),
+              sortTime: getTimeMs(namespaceCommitment.updatedAtMs, namespaceCommitment.updatedAt),
+              sequence: getTimeMs(namespaceCommitment.updatedAtMs, namespaceCommitment.updatedAt),
             },
           ]
         : []),
-    ].sort((a, b) => b.sortTime - a.sortTime);
+    ].sort(compareNewestFirst);
 
-    const lastActionAt = timeline[0]?.time ?? "-";
+    const lastActionAt = latestDisposalAction?.time ?? timeline[0]?.time ?? "-";
 
     return {
       namespace,
       violated: namespaceViolations.length > 0,
-      banned: namespaceBans.some((item) => item.active),
+      banned: Boolean(latestDisposalAction?.kind === "ban" && latestDisposalAction.active),
       commitmentUploaded: Boolean(namespaceCommitment),
       lastActionAt,
       commitment: namespaceCommitment
@@ -286,7 +347,7 @@ function buildNamespaceProfiles(
           }
         : undefined,
       recentViolations: namespaceViolations.slice(0, 5),
-      timeline: timeline.map(({ sortTime: _sortTime, ...item }) => item),
+      timeline: timeline.map(({ sortTime: _sortTime, sequence: _sequence, ...item }) => item),
     };
   });
 

--- a/sealos-complik-admin/web/src/contexts/AppDataContext.tsx
+++ b/sealos-complik-admin/web/src/contexts/AppDataContext.tsx
@@ -126,7 +126,6 @@ type DisposalAction = {
   tone: ActivityItem["tone"];
   sortTime: number;
   sequence: number;
-  active: boolean;
 };
 
 function buildDisposalActions(bans: BanRecord[], unbans: UnbanRecord[]) {
@@ -141,7 +140,6 @@ function buildDisposalActions(bans: BanRecord[], unbans: UnbanRecord[]) {
       tone: "warn" as const,
       sortTime: getTimeMs(item.createdAtMs, item.createdAt),
       sequence: item.apiId * 2,
-      active: item.active,
     })),
     ...unbans.map((item) => ({
       id: `timeline-${item.id}`,
@@ -153,7 +151,6 @@ function buildDisposalActions(bans: BanRecord[], unbans: UnbanRecord[]) {
       tone: "success" as const,
       sortTime: getTimeMs(item.createdAtMs, item.createdAt),
       sequence: item.apiId * 2 + 1,
-      active: false,
     })),
   ];
 
@@ -166,7 +163,7 @@ function isNamespaceBanned(namespace: string, bans: BanRecord[], unbans: UnbanRe
     unbans.filter((item) => item.namespace === namespace),
   )[0];
 
-  return Boolean(latestAction?.kind === "ban" && latestAction.active);
+  return latestAction?.kind === "ban";
 }
 
 function buildStats(violations: ViolationRecord[], bans: BanRecord[], unbans: UnbanRecord[]): StatCardItem[] {
@@ -336,7 +333,7 @@ function buildNamespaceProfiles(
     return {
       namespace,
       violated: namespaceViolations.length > 0,
-      banned: Boolean(latestDisposalAction?.kind === "ban" && latestDisposalAction.active),
+      banned: latestDisposalAction?.kind === "ban",
       commitmentUploaded: Boolean(namespaceCommitment),
       lastActionAt,
       commitment: namespaceCommitment

--- a/sealos-complik-admin/web/src/lib/api.ts
+++ b/sealos-complik-admin/web/src/lib/api.ts
@@ -183,7 +183,9 @@ function toCommitmentRecord(item: CommitmentDto): CommitmentRecord {
     fileName: item.file_name,
     fileUrl: item.file_url,
     createdAt: formatDateTime(item.created_at),
+    createdAtMs: new Date(item.created_at).getTime(),
     updatedAt: formatDateTime(item.updated_at),
+    updatedAtMs: new Date(item.updated_at).getTime(),
   };
 }
 
@@ -200,8 +202,10 @@ function toBanRecord(item: BanDto): BanRecord {
     screenshotUrls: item.screenshot_urls ?? [],
     operatorName: item.operator_name,
     banStartTime: formatDateTime(item.ban_start_time),
+    banStartTimeMs: startAt,
     banEndTime: item.ban_end_time ? formatDateTime(item.ban_end_time) : undefined,
     createdAt: formatDateTime(item.created_at),
+    createdAtMs: new Date(item.created_at).getTime(),
     updatedAt: formatDateTime(item.updated_at),
     active: !Number.isNaN(startAt) && startAt <= now && (endAt === null || endAt >= now),
   };
@@ -214,6 +218,7 @@ function toUnbanRecord(item: UnbanDto): UnbanRecord {
     namespace: item.namespace,
     operatorName: item.operator_name,
     createdAt: formatDateTime(item.created_at),
+    createdAtMs: new Date(item.created_at).getTime(),
     updatedAt: formatDateTime(item.updated_at),
   };
 }
@@ -230,10 +235,13 @@ function toComplikViolationRecord(item: ComplikViolationDto): ViolationRecord {
     url: item.url,
     keywords: item.keywords ?? [],
     detectedAt: formatDateTime(item.detected_at),
+    detectedAtMs: new Date(item.detected_at).getTime(),
     description: item.description ?? "暂无说明",
     rawPayload: item.raw_payload ? stringifyJson(item.raw_payload) : undefined,
     createdAt: item.created_at ? formatDateTime(item.created_at) : undefined,
+    createdAtMs: item.created_at ? new Date(item.created_at).getTime() : undefined,
     updatedAt: item.updated_at ? formatDateTime(item.updated_at) : undefined,
+    updatedAtMs: item.updated_at ? new Date(item.updated_at).getTime() : undefined,
   };
 }
 
@@ -252,10 +260,13 @@ function toProcscanViolationRecord(item: ProcscanViolationDto): ViolationRecord 
     labelActionResult: item.label_action_result,
     message: item.message,
     detectedAt: formatDateTime(item.detected_at),
+    detectedAtMs: new Date(item.detected_at).getTime(),
     description: item.message,
     rawPayload: item.raw_payload ? stringifyJson(item.raw_payload) : undefined,
     createdAt: item.created_at ? formatDateTime(item.created_at) : undefined,
+    createdAtMs: item.created_at ? new Date(item.created_at).getTime() : undefined,
     updatedAt: item.updated_at ? formatDateTime(item.updated_at) : undefined,
+    updatedAtMs: item.updated_at ? new Date(item.updated_at).getTime() : undefined,
   };
 }
 

--- a/sealos-complik-admin/web/src/lib/api.ts
+++ b/sealos-complik-admin/web/src/lib/api.ts
@@ -191,6 +191,7 @@ function toCommitmentRecord(item: CommitmentDto): CommitmentRecord {
 
 function toBanRecord(item: BanDto): BanRecord {
   const startAt = new Date(item.ban_start_time).getTime();
+  const endAt = item.ban_end_time ? new Date(item.ban_end_time).getTime() : undefined;
 
   return {
     id: `ban-${item.id}`,
@@ -202,6 +203,7 @@ function toBanRecord(item: BanDto): BanRecord {
     banStartTime: formatDateTime(item.ban_start_time),
     banStartTimeMs: startAt,
     banEndTime: item.ban_end_time ? formatDateTime(item.ban_end_time) : undefined,
+    banEndTimeMs: endAt,
     createdAt: formatDateTime(item.created_at),
     createdAtMs: new Date(item.created_at).getTime(),
     updatedAt: formatDateTime(item.updated_at),

--- a/sealos-complik-admin/web/src/lib/api.ts
+++ b/sealos-complik-admin/web/src/lib/api.ts
@@ -190,9 +190,7 @@ function toCommitmentRecord(item: CommitmentDto): CommitmentRecord {
 }
 
 function toBanRecord(item: BanDto): BanRecord {
-  const now = Date.now();
   const startAt = new Date(item.ban_start_time).getTime();
-  const endAt = item.ban_end_time ? new Date(item.ban_end_time).getTime() : null;
 
   return {
     id: `ban-${item.id}`,
@@ -207,7 +205,6 @@ function toBanRecord(item: BanDto): BanRecord {
     createdAt: formatDateTime(item.created_at),
     createdAtMs: new Date(item.created_at).getTime(),
     updatedAt: formatDateTime(item.updated_at),
-    active: !Number.isNaN(startAt) && startAt <= now && (endAt === null || endAt >= now),
   };
 }
 

--- a/sealos-complik-admin/web/src/types.ts
+++ b/sealos-complik-admin/web/src/types.ts
@@ -113,6 +113,7 @@ export type BanRecord = {
   banStartTime: string;
   banStartTimeMs: number;
   banEndTime?: string;
+  banEndTimeMs?: number;
   createdAt: string;
   createdAtMs: number;
   updatedAt: string;

--- a/sealos-complik-admin/web/src/types.ts
+++ b/sealos-complik-admin/web/src/types.ts
@@ -116,7 +116,6 @@ export type BanRecord = {
   createdAt: string;
   createdAtMs: number;
   updatedAt: string;
-  active: boolean;
 };
 
 export type UnbanRecord = {

--- a/sealos-complik-admin/web/src/types.ts
+++ b/sealos-complik-admin/web/src/types.ts
@@ -50,10 +50,13 @@ export type ViolationRecord = {
   labelActionResult?: string;
   message?: string;
   detectedAt: string;
+  detectedAtMs: number;
   description: string;
   rawPayload?: string;
   createdAt?: string;
+  createdAtMs?: number;
   updatedAt?: string;
+  updatedAtMs?: number;
 };
 
 export type TimelineRecord = {
@@ -95,7 +98,9 @@ export type CommitmentRecord = {
   fileName: string;
   fileUrl: string;
   createdAt: string;
+  createdAtMs: number;
   updatedAt: string;
+  updatedAtMs: number;
 };
 
 export type BanRecord = {
@@ -106,8 +111,10 @@ export type BanRecord = {
   screenshotUrls: string[];
   operatorName: string;
   banStartTime: string;
+  banStartTimeMs: number;
   banEndTime?: string;
   createdAt: string;
+  createdAtMs: number;
   updatedAt: string;
   active: boolean;
 };
@@ -118,6 +125,7 @@ export type UnbanRecord = {
   namespace: string;
   operatorName: string;
   createdAt: string;
+  createdAtMs: number;
   updatedAt: string;
 };
 


### PR DESCRIPTION
## Changes

- Determine admin ban status from the latest ban/unban action
- Let active ban records override unban state in the admin UI
- Keep admin status fields aligned between API response and frontend state
- Require compliance review descriptions and explanations to use Simplified Chinese
- Keep compliance keywords as English JSON arrays

## Validation

- Synced with latest upstream/main
- Resolved compliance prompt merge conflict
