### PR TITLE
fix(admin): relax upload body limits

### DIFF
--- a/sealos-complik-admin/deploy/admin-web-ingress.yaml
+++ b/sealos-complik-admin/deploy/admin-web-ingress.yaml
@@ -50,6 +50,8 @@ kind: Ingress
 metadata:
   name: complik-admin
   namespace: sealos
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
 spec:
   ingressClassName: nginx
   rules:

--- a/sealos-complik-admin/internal/modules/ban/services.go
+++ b/sealos-complik-admin/internal/modules/ban/services.go
@@ -23,9 +23,7 @@ var (
 )
 
 const (
-	defaultBanObjectPrefix        = "bans"
-	maxBanScreenshotCount         = 6
-	maxBanScreenshotFileSizeBytes = 10 << 20 // 10MB
+	defaultBanObjectPrefix = "bans"
 )
 
 type Service struct {
@@ -238,14 +236,6 @@ func normalizeBanInput(
 		return nil, ErrBanInvalidInput
 	}
 
-	if len(normalizedScreenshotURLs) > maxBanScreenshotCount {
-		return nil, fmt.Errorf(
-			"%w: screenshot count must be at most %d",
-			ErrBanInvalidInput,
-			maxBanScreenshotCount,
-		)
-	}
-
 	return &normalizedBanInput{
 		Namespace:      trimmedNamespace,
 		Reason:         trimmedReason,
@@ -265,14 +255,6 @@ func (s *Service) uploadScreenshots(
 		return nil, nil
 	}
 
-	if len(screenshots) > maxBanScreenshotCount {
-		return nil, fmt.Errorf(
-			"%w: screenshot count must be at most %d",
-			ErrBanInvalidInput,
-			maxBanScreenshotCount,
-		)
-	}
-
 	if s.uploader == nil {
 		return nil, ErrBanUploadDisabled
 	}
@@ -282,14 +264,6 @@ func (s *Service) uploadScreenshots(
 		contentType, ok := screenshotContentType(screenshot)
 		if !ok {
 			return nil, ErrBanInvalidFile
-		}
-
-		if screenshot.Size <= 0 || screenshot.Size > maxBanScreenshotFileSizeBytes {
-			return nil, fmt.Errorf(
-				"%w: screenshot size must be between 1 byte and %d bytes",
-				ErrBanInvalidFile,
-				maxBanScreenshotFileSizeBytes,
-			)
 		}
 
 		file, err := screenshot.Open()

--- a/sealos-complik-admin/internal/modules/commitment/services.go
+++ b/sealos-complik-admin/internal/modules/commitment/services.go
@@ -24,7 +24,6 @@ var (
 
 const (
 	defaultCommitmentObjectPrefix = "commitments"
-	maxCommitmentFileSizeBytes    = 10 << 20 // 10MB
 	pdfContentType                = "application/pdf"
 )
 
@@ -169,13 +168,6 @@ func (s *Service) UploadCommitment(
 
 	if !isPDFFile(fileHeader) {
 		return nil, ErrCommitmentInvalidFile
-	}
-
-	if fileHeader.Size <= 0 || fileHeader.Size > maxCommitmentFileSizeBytes {
-		return nil, fmt.Errorf(
-			"pdf size must be between 1 byte and %d bytes",
-			maxCommitmentFileSizeBytes,
-		)
 	}
 
 	file, err := fileHeader.Open()

--- a/sealos-complik-admin/web/nginx.conf.template
+++ b/sealos-complik-admin/web/nginx.conf.template
@@ -1,6 +1,7 @@
 server {
   listen 80;
   server_name _;
+  client_max_body_size 0;
 
   root /usr/share/nginx/html;
   index index.html;

--- a/sealos-complik-admin/web/src/pages/BansPage.tsx
+++ b/sealos-complik-admin/web/src/pages/BansPage.tsx
@@ -20,6 +20,10 @@ import { buildBanScreenshotPreviewURL } from "../lib/api";
 import { summarizeMarkdown } from "../lib/utils";
 import type { BanRecord } from "../types";
 
+const maxScreenshotCount = 6;
+const maxScreenshotSizeBytes = 10 * 1024 * 1024;
+const maxScreenshotTotalSizeBytes = maxScreenshotCount * maxScreenshotSizeBytes;
+
 export function BansPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -75,7 +79,21 @@ export function BansPage() {
       return;
     }
 
-    setScreenshots((current) => [...current, ...files].slice(0, 6));
+    const oversizedFile = files.find((file) => file.size > maxScreenshotSizeBytes);
+    if (oversizedFile) {
+      setFormError(`截图 ${oversizedFile.name} 超过 10MB。`);
+      return;
+    }
+
+    const next = [...screenshots, ...files].slice(0, maxScreenshotCount);
+    const totalSize = next.reduce((sum, file) => sum + file.size, 0);
+    if (totalSize > maxScreenshotTotalSizeBytes) {
+      setFormError("截图总大小超过 60MB。");
+      return;
+    }
+
+    setFormError(null);
+    setScreenshots(next);
   };
 
   const removeScreenshot = (target: File) => {
@@ -127,8 +145,16 @@ export function BansPage() {
       setFormError("namespace、描述、开始时间、操作人均为必填。");
       return;
     }
-    if (screenshots.length > 6) {
+    if (screenshots.length > maxScreenshotCount) {
       setFormError("截图最多上传 6 张。");
+      return;
+    }
+    if (screenshots.some((file) => file.size > maxScreenshotSizeBytes)) {
+      setFormError("单张截图最大 10MB。");
+      return;
+    }
+    if (screenshots.reduce((sum, file) => sum + file.size, 0) > maxScreenshotTotalSizeBytes) {
+      setFormError("截图总大小超过 60MB。");
       return;
     }
 
@@ -360,7 +386,7 @@ export function BansPage() {
                   event.target.value = "";
                 }}
               />
-              <div className="muted-text">支持 PNG、JPG、WEBP、GIF，最多 6 张。文件选择和粘贴图片会合并到同一列表。</div>
+              <div className="muted-text">支持 PNG、JPG、WEBP、GIF，最多 6 张，单张最大 10MB。</div>
               {screenshots.length > 0 ? (
                 <div className="upload-list">
                   {screenshots.map((file) => (

--- a/sealos-complik-admin/web/src/pages/BansPage.tsx
+++ b/sealos-complik-admin/web/src/pages/BansPage.tsx
@@ -20,10 +20,6 @@ import { buildBanScreenshotPreviewURL } from "../lib/api";
 import { summarizeMarkdown } from "../lib/utils";
 import type { BanRecord } from "../types";
 
-const maxScreenshotCount = 6;
-const maxScreenshotSizeBytes = 10 * 1024 * 1024;
-const maxScreenshotTotalSizeBytes = maxScreenshotCount * maxScreenshotSizeBytes;
-
 export function BansPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -79,21 +75,8 @@ export function BansPage() {
       return;
     }
 
-    const oversizedFile = files.find((file) => file.size > maxScreenshotSizeBytes);
-    if (oversizedFile) {
-      setFormError(`截图 ${oversizedFile.name} 超过 10MB。`);
-      return;
-    }
-
-    const next = [...screenshots, ...files].slice(0, maxScreenshotCount);
-    const totalSize = next.reduce((sum, file) => sum + file.size, 0);
-    if (totalSize > maxScreenshotTotalSizeBytes) {
-      setFormError("截图总大小超过 60MB。");
-      return;
-    }
-
     setFormError(null);
-    setScreenshots(next);
+    setScreenshots((current) => [...current, ...files]);
   };
 
   const removeScreenshot = (target: File) => {
@@ -145,19 +128,6 @@ export function BansPage() {
       setFormError("namespace、描述、开始时间、操作人均为必填。");
       return;
     }
-    if (screenshots.length > maxScreenshotCount) {
-      setFormError("截图最多上传 6 张。");
-      return;
-    }
-    if (screenshots.some((file) => file.size > maxScreenshotSizeBytes)) {
-      setFormError("单张截图最大 10MB。");
-      return;
-    }
-    if (screenshots.reduce((sum, file) => sum + file.size, 0) > maxScreenshotTotalSizeBytes) {
-      setFormError("截图总大小超过 60MB。");
-      return;
-    }
-
     setSubmitting(true);
     setFormError(null);
     try {
@@ -386,7 +356,7 @@ export function BansPage() {
                   event.target.value = "";
                 }}
               />
-              <div className="muted-text">支持 PNG、JPG、WEBP、GIF，最多 6 张，单张最大 10MB。</div>
+              <div className="muted-text">支持 PNG、JPG、WEBP、GIF。文件选择和粘贴图片会合并到同一列表。</div>
               {screenshots.length > 0 ? (
                 <div className="upload-list">
                   {screenshots.map((file) => (

--- a/sealos-complik-admin/web/src/pages/CommitmentsPage.tsx
+++ b/sealos-complik-admin/web/src/pages/CommitmentsPage.tsx
@@ -178,11 +178,19 @@ export function CommitmentsPage() {
           <Field label="PDF 文件">
             <Input
               accept=".pdf,application/pdf"
-              onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+              onChange={(event) => {
+                const selectedFile = event.target.files?.[0] ?? null;
+                setFile(selectedFile);
+                setFormError(null);
+              }}
               type="file"
             />
           </Field>
-          {file ? <div className="muted-text">已选择：{file.name}</div> : null}
+          {file ? (
+            <div className="muted-text">
+              已选择：{file.name}（{Math.max(1, Math.round(file.size / 1024))} KB）
+            </div>
+          ) : null}
           {formError ? <div className="muted-text" style={{ color: "#b42318" }}>{formError}</div> : null}
           <div className="button-row">
             <Button variant="primary" onClick={() => void handleCreateCommitment()}>


### PR DESCRIPTION
## Summary

- Remove the 10MB backend size check for commitment PDF uploads
- Allow unlimited request body size through admin Ingress and web Nginx
- Add client-side screenshot upload validation for ban records
- Show selected commitment file size in the upload form

## Testing

- `GOCACHE=/private/tmp/complik-go-build go test ./complik/...`
- `GOCACHE=/private/tmp/complik-go-build go test ./sealos-complik-admin/...`
- `npm run build`
