### PR TITLE
ci: split validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,28 @@ on:
     paths-ignore:
       - "**/*.md"
 
+permissions:
+  contents: read
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  lint-and-test:
-    name: Lint and Test
+  go-test:
+    name: Go Test (${{ matrix.module }})
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: complik
+            path: complik
+          - module: procscan
+            path: procscan
+          - module: admin
+            path: sealos-complik-admin
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -29,33 +43,73 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: "go.work"
+          go-version-file: go.work
+          cache-dependency-path: |
+            go.sum
+            go.work.sum
+            complik/go.sum
+            procscan/go.sum
+            sealos-complik-admin/go.sum
 
-      - name: Go test (complik)
-        working-directory: complik
-        run: go test -v -timeout 30s -count=1 ./...
+      - name: Test
+        working-directory: ${{ matrix.path }}
+        run: go test -v -timeout 5m -count=1 ./...
 
-      - name: Go test (procscan)
-        working-directory: procscan
-        run: go test -v -timeout 30s -count=1 ./...
+  go-lint:
+    name: Go Lint (${{ matrix.module }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: complik
+            path: complik
+          - module: procscan
+            path: procscan
+          - module: admin
+            path: sealos-complik-admin
 
-      - name: Run Linter (complik)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.work
+          cache-dependency-path: |
+            go.sum
+            go.work.sum
+            complik/go.sum
+            procscan/go.sum
+            sealos-complik-admin/go.sum
+
+      - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
-          working-directory: complik
+          version: v2.11.3
+          working-directory: ${{ matrix.path }}
           args: --color=always
 
-      - name: Run Linter (procscan)
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: latest
-          working-directory: procscan
-          args: --color=always
+  admin-web-build:
+    name: Admin Web Build
+    runs-on: ubuntu-24.04
 
-      - name: Run Linter (admin)
-        uses: golangci/golangci-lint-action@v9
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
         with:
-          version: latest
-          working-directory: sealos-complik-admin
-          args: --color=always
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: sealos-complik-admin/web/package-lock.json
+
+      - name: Install Dependencies
+        working-directory: sealos-complik-admin/web
+        run: npm ci
+
+      - name: Build
+        working-directory: sealos-complik-admin/web
+        run: npm run build

--- a/procscan/internal/core/processor/process.go
+++ b/procscan/internal/core/processor/process.go
@@ -307,6 +307,7 @@ func (p *Processor) getProcessName(cmdline string) string {
 // getContainerIDFromPID extracts container ID from process cgroup information
 func (p *Processor) getContainerIDFromPID(pid int) string {
 	cgroupPath := filepath.Join(p.ProcPath, strconv.Itoa(pid), "cgroup")
+
 	content, err := os.ReadFile(cgroupPath)
 	if err != nil {
 		return ""

--- a/procscan/internal/core/processor/process_test.go
+++ b/procscan/internal/core/processor/process_test.go
@@ -413,12 +413,14 @@ var _ = Describe("Processor", func() {
 			cgroupContent := `12:memory:/kubepods/besteffort/pod123/cri-containerd-aabbccddee112233445566778899aabbccddee112233445566778899aabbccdd.scope
 11:cpu:/kubepods/besteffort/pod123/cri-containerd-aabbccddee112233445566778899aabbccddee112233445566778899aabbccdd.scope`
 			cgroupPath := filepath.Join(pidDir, "cgroup")
-			err := os.WriteFile(cgroupPath, []byte(cgroupContent), 0644)
+			err := os.WriteFile(cgroupPath, []byte(cgroupContent), 0o600)
 			Expect(err).NotTo(HaveOccurred())
 
 			containerID := processor.getContainerIDFromPID(1234)
 
-			Expect(containerID).To(Equal("aabbccddee112233445566778899aabbccddee112233445566778899aabbccdd"))
+			Expect(containerID).To(Equal(
+				"aabbccddee112233445566778899aabbccddee112233445566778899aabbccdd",
+			))
 			Expect(isHexString(containerID)).To(BeTrue())
 		})
 

--- a/sealos-complik-admin/internal/infra/database/database.go
+++ b/sealos-complik-admin/internal/infra/database/database.go
@@ -25,7 +25,7 @@ func Init(cfg config.DatabaseConfig) (*gorm.DB, error) {
 		return client, nil
 	}
 	// verify config before trying to connect to avoid unnecessary connection attempts with invalid config
-	if err := validateConfig(cfg); err != nil {
+	if err := ValidateConfig(cfg); err != nil {
 		return nil, err
 	}
 	// Create database if it does not exist
@@ -117,8 +117,8 @@ func serverDSN(cfg config.DatabaseConfig) string {
 	)
 }
 
-// validateConfig checks the minimum fields required to build a valid MySQL DSN.
-func validateConfig(cfg config.DatabaseConfig) error {
+// ValidateConfig checks the minimum fields required to build a valid MySQL DSN.
+func ValidateConfig(cfg config.DatabaseConfig) error {
 	if cfg.Host == "" {
 		return errors.New("database host is required")
 	}
@@ -167,7 +167,8 @@ func isDatabaseNameChar(r rune) bool {
 }
 
 func createDatabaseQuery(name string) string {
-	return "CREATE DATABASE IF NOT EXISTS " + quoteIdentifier(name) + " CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+	return "CREATE DATABASE IF NOT EXISTS " + quoteIdentifier(name) +
+		" CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
 }
 
 func open(dsn string) (*gorm.DB, error) {

--- a/sealos-complik-admin/internal/infra/database/database.go
+++ b/sealos-complik-admin/internal/infra/database/database.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	pingTimeout = 5 * time.Second
+	pingTimeout           = 5 * time.Second
+	maxDatabaseNameLength = 64
 )
 
 var client *gorm.DB
@@ -57,10 +58,7 @@ func createDatabase(cfg config.DatabaseConfig) error {
 	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
 	defer cancel()
 
-	query := fmt.Sprintf(
-		"CREATE DATABASE IF NOT EXISTS %s CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
-		quoteIdentifier(cfg.Name),
-	)
+	query := createDatabaseQuery(cfg.Name)
 	if err := db.WithContext(ctx).Exec(query).Error; err != nil {
 		return fmt.Errorf("create database %q: %w", cfg.Name, err)
 	}
@@ -137,7 +135,39 @@ func validateConfig(cfg config.DatabaseConfig) error {
 		return errors.New("database name is required")
 	}
 
+	if err := validateDatabaseName(cfg.Name); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func validateDatabaseName(name string) error {
+	if len(name) > maxDatabaseNameLength {
+		return fmt.Errorf("database name %q exceeds %d characters", name, maxDatabaseNameLength)
+	}
+
+	for _, r := range name {
+		if isDatabaseNameChar(r) {
+			continue
+		}
+
+		return fmt.Errorf("database name %q contains invalid character %q", name, r)
+	}
+
+	return nil
+}
+
+func isDatabaseNameChar(r rune) bool {
+	return r >= 'a' && r <= 'z' ||
+		r >= 'A' && r <= 'Z' ||
+		r >= '0' && r <= '9' ||
+		r == '_' ||
+		r == '-'
+}
+
+func createDatabaseQuery(name string) string {
+	return "CREATE DATABASE IF NOT EXISTS " + quoteIdentifier(name) + " CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
 }
 
 func open(dsn string) (*gorm.DB, error) {

--- a/sealos-complik-admin/internal/infra/database/database_test.go
+++ b/sealos-complik-admin/internal/infra/database/database_test.go
@@ -1,11 +1,14 @@
-package database
+package database_test
 
 import (
 	"strings"
 	"testing"
 
 	"sealos-complik-admin/internal/infra/config"
+	"sealos-complik-admin/internal/infra/database"
 )
+
+const maxDatabaseNameLength = 64
 
 func TestValidateConfigAcceptsDatabaseNames(t *testing.T) {
 	tests := []string{
@@ -55,4 +58,8 @@ func validDatabaseConfig() config.DatabaseConfig {
 		Username: "root",
 		Name:     "sealos-complik-admin",
 	}
+}
+
+func validateConfig(cfg config.DatabaseConfig) error {
+	return database.ValidateConfig(cfg)
 }

--- a/sealos-complik-admin/internal/infra/database/database_test.go
+++ b/sealos-complik-admin/internal/infra/database/database_test.go
@@ -1,0 +1,58 @@
+package database
+
+import (
+	"strings"
+	"testing"
+
+	"sealos-complik-admin/internal/infra/config"
+)
+
+func TestValidateConfigAcceptsDatabaseNames(t *testing.T) {
+	tests := []string{
+		"sealos-complik-admin",
+		"sealos_complik_admin",
+		"CompliK2026",
+		strings.Repeat("a", maxDatabaseNameLength),
+	}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := validDatabaseConfig()
+			cfg.Name = name
+
+			if err := validateConfig(cfg); err != nil {
+				t.Fatalf("validateConfig() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateConfigRejectsDatabaseNames(t *testing.T) {
+	tests := []string{
+		"sealos complik",
+		"sealos`complik",
+		"sealos.complik",
+		"sealos/complik",
+		strings.Repeat("a", maxDatabaseNameLength+1),
+	}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := validDatabaseConfig()
+			cfg.Name = name
+
+			if err := validateConfig(cfg); err == nil {
+				t.Fatal("validateConfig() error = nil")
+			}
+		})
+	}
+}
+
+func validDatabaseConfig() config.DatabaseConfig {
+	return config.DatabaseConfig{
+		Host:     "localhost",
+		Port:     3306,
+		Username: "root",
+		Name:     "sealos-complik-admin",
+	}
+}

--- a/sealos-complik-admin/internal/modules/ban/repository.go
+++ b/sealos-complik-admin/internal/modules/ban/repository.go
@@ -2,6 +2,7 @@ package ban
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"gorm.io/gorm"
@@ -84,9 +85,10 @@ func (r *Repository) HasActiveBan(
 ) (bool, error) {
 	action, err := r.getLatestBanStatusAction(ctx, namespace, now)
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return false, nil
 		}
+
 		return false, err
 	}
 


### PR DESCRIPTION
## Changes

- Split CI into Go test, Go lint, and admin web build jobs.
- Run Go checks for `complik`, `procscan`, and `sealos-complik-admin`.
- Add admin web build validation.
- Fix lint issues required by the new CI.

## Validation

- Go tests passed
- Go lint passed
- Admin web build passed