### PR TITLE
fix(procscan): log container metadata degradation

### DIFF
--- a/procscan/internal/core/processor/process.go
+++ b/procscan/internal/core/processor/process.go
@@ -201,16 +201,21 @@ func (p *Processor) AnalyzeProcess(pid int) (*models.ProcessInfo, error) {
 	// Step 5: Query container info on-demand when container metadata is available.
 	var podName, namespace string
 	if containerID == "" {
-		procLogger.Debug(
-			"Unable to determine container ID, continue alerting without container metadata",
-		)
+		procLogger.WithFields(logrus.Fields{
+			"container_metadata_degraded": true,
+			"container_metadata_reason":   "container_id_missing",
+			"main_process_pid":            mainProcessPID,
+		}).Warn("Unable to determine container ID, continue alerting without container metadata")
 	} else {
 		podName, namespace, err = container.GetContainerInfo(containerID)
 		if err != nil {
 			procLogger.WithFields(logrus.Fields{
-				"containerID": containerID,
-				"error":       err.Error(),
-			}).Debug("Failed to get container info, continue alerting without pod/namespace")
+				"containerID":                 containerID,
+				"container_metadata_degraded": true,
+				"container_metadata_reason":   "cri_container_info_failed",
+				"container_metadata_error":    err.Error(),
+				"main_process_pid":            mainProcessPID,
+			}).Warn("Failed to get container info, continue alerting without pod/namespace")
 
 			podName = ""
 			namespace = ""


### PR DESCRIPTION
## What changed
- Log container metadata degradation as warnings when container ID lookup or CRI metadata lookup fails.
- Add structured fields for degradation reason, main process PID, container ID, and lookup error.
- Keep alert generation flowing with empty pod/namespace metadata when lookup fails.

## Testing
- Skipped; logging-only change.