### PR TITLE
feat: paginate admin compliance views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 *.tsbuildinfo
 /test/
+.superpowers/
+.fork-skill/
+codex-work/

--- a/sealos-complik-admin/README.md
+++ b/sealos-complik-admin/README.md
@@ -106,6 +106,8 @@ Notes:
 - `oss.object_prefix` is used for commitment and ban screenshot object keys.
 - Ban screenshots support admin-side proxy preview through `/api/bans/screenshots`.
 - CompliK and Procscan violation list endpoints return illegal events by default. `include_all=true` returns the full event stream.
+- List endpoints for configs, commitments, bans, unbans, and violations support `page`. Paginated responses use a fixed page size of 10.
+- Violation list endpoints also support `keyword` and `time_range` (`24h`, `7d`, `30d`, `all`).
 
 ### Run Locally
 
@@ -145,26 +147,26 @@ If MySQL is not running inside the same network as the container, update `config
 | --- | --- | --- |
 | `GET` | `/health` | Health check |
 | `POST` | `/api/configs` | Create project config |
-| `GET` | `/api/configs` | List project configs |
+| `GET` | `/api/configs` | List project configs; `page` and `keyword` return paginated results |
 | `GET` | `/api/configs/type/:config_type` | List project configs by type |
 | `GET` | `/api/configs/:config_name` | Get project config by name |
 | `PUT` | `/api/configs/:config_name` | Update project config |
 | `DELETE` | `/api/configs/:config_name` | Delete project config |
 | `POST` | `/api/commitments` | Create commitment |
 | `POST` | `/api/commitments/upload` | Upload commitment file |
-| `GET` | `/api/commitments` | List commitments |
+| `GET` | `/api/commitments` | List commitments; `page` and `keyword` return paginated results |
 | `GET` | `/api/commitments/:namespace` | Get commitment by namespace |
 | `GET` | `/api/commitments/:namespace/download` | Download commitment file |
 | `PUT` | `/api/commitments/:namespace` | Update commitment |
 | `DELETE` | `/api/commitments/:namespace` | Delete commitment |
 | `POST` | `/api/complik-violations` | Create CompliK violation event |
-| `GET` | `/api/complik-violations` | List CompliK illegal events, `include_all=true` returns all events |
+| `GET` | `/api/complik-violations` | List CompliK illegal events, `include_all=true` returns all events; `page`, `keyword`, and `time_range` return paginated results |
 | `GET` | `/api/complik-violations/:namespace` | Get CompliK events by namespace |
 | `DELETE` | `/api/complik-violations/id/:id` | Delete CompliK event by id |
 | `DELETE` | `/api/complik-violations/:namespace` | Delete CompliK events by namespace |
 | `GET` | `/api/namespaces/:namespace/complik-violations-status` | Check whether a namespace has CompliK illegal events |
 | `POST` | `/api/procscan-violations` | Create Procscan violation event |
-| `GET` | `/api/procscan-violations` | List Procscan illegal events, `include_all=true` returns all events |
+| `GET` | `/api/procscan-violations` | List Procscan illegal events, `include_all=true` returns all events; `page`, `keyword`, and `time_range` return paginated results |
 | `GET` | `/api/procscan-violations/:namespace` | Get Procscan events by namespace |
 | `DELETE` | `/api/procscan-violations/id/:id` | Delete Procscan event by id |
 | `DELETE` | `/api/procscan-violations/:namespace` | Delete Procscan events by namespace |
@@ -172,12 +174,12 @@ If MySQL is not running inside the same network as the container, update `config
 | `POST` | `/api/bans` | Create ban record |
 | `POST` | `/api/bans/upload` | Create ban record with screenshot upload |
 | `GET` | `/api/bans/screenshots` | Proxy preview for ban screenshots |
-| `GET` | `/api/bans` | List ban records |
+| `GET` | `/api/bans` | List ban records; `page`, `keyword`, and `operator_name` return paginated results |
 | `GET` | `/api/bans/:namespace` | Get bans by namespace |
 | `DELETE` | `/api/bans/id/:id` | Delete a ban record by id |
 | `GET` | `/api/namespaces/:namespace/ban-status` | Check whether a namespace is banned |
 | `POST` | `/api/unbans` | Create unban record |
-| `GET` | `/api/unbans` | List unban records |
+| `GET` | `/api/unbans` | List unban records; `page`, `keyword`, and `operator_name` return paginated results |
 | `GET` | `/api/unbans/:namespace` | Get unban records by namespace |
 | `DELETE` | `/api/unbans/id/:id` | Delete an unban record by id |
 
@@ -343,6 +345,8 @@ oss:
 - `oss.object_prefix` 用于承诺书和封禁截图对象路径前缀。
 - 封禁截图支持通过 `/api/bans/screenshots` 走 admin 代理预览。
 - CompliK 和 Procscan 违规列表接口默认返回违规事件，`include_all=true` 返回全量事件。
+- 配置、承诺书、封禁、解封和违规列表接口支持 `page`，分页响应每页固定 10 条。
+- 违规列表接口额外支持 `keyword` 和 `time_range`（`24h`、`7d`、`30d`、`all`）。
 
 ### 本地运行
 
@@ -382,26 +386,26 @@ docker run --rm -p 8080:8080 sealos-complik-admin
 | --- | --- | --- |
 | `GET` | `/health` | 健康检查 |
 | `POST` | `/api/configs` | 创建项目配置 |
-| `GET` | `/api/configs` | 查询项目配置列表 |
+| `GET` | `/api/configs` | 查询项目配置列表；`page`、`keyword` 返回分页结果 |
 | `GET` | `/api/configs/type/:config_type` | 按配置类型查询项目配置 |
 | `GET` | `/api/configs/:config_name` | 按名称查询项目配置 |
 | `PUT` | `/api/configs/:config_name` | 更新项目配置 |
 | `DELETE` | `/api/configs/:config_name` | 删除项目配置 |
 | `POST` | `/api/commitments` | 创建承诺记录 |
 | `POST` | `/api/commitments/upload` | 上传承诺书文件 |
-| `GET` | `/api/commitments` | 查询承诺记录列表 |
+| `GET` | `/api/commitments` | 查询承诺记录列表；`page`、`keyword` 返回分页结果 |
 | `GET` | `/api/commitments/:namespace` | 按 namespace 查询承诺记录 |
 | `GET` | `/api/commitments/:namespace/download` | 下载承诺书文件 |
 | `PUT` | `/api/commitments/:namespace` | 更新承诺记录 |
 | `DELETE` | `/api/commitments/:namespace` | 删除承诺记录 |
 | `POST` | `/api/complik-violations` | 创建 CompliK 违规事件 |
-| `GET` | `/api/complik-violations` | 查询 CompliK 违规事件列表，`include_all=true` 返回全量事件 |
+| `GET` | `/api/complik-violations` | 查询 CompliK 违规事件列表，`include_all=true` 返回全量事件；`page`、`keyword`、`time_range` 返回分页结果 |
 | `GET` | `/api/complik-violations/:namespace` | 按 namespace 查询 CompliK 事件 |
 | `DELETE` | `/api/complik-violations/id/:id` | 按 id 删除 CompliK 事件 |
 | `DELETE` | `/api/complik-violations/:namespace` | 按 namespace 删除 CompliK 事件 |
 | `GET` | `/api/namespaces/:namespace/complik-violations-status` | 查询 namespace 是否存在 CompliK 违规事件 |
 | `POST` | `/api/procscan-violations` | 创建 Procscan 违规事件 |
-| `GET` | `/api/procscan-violations` | 查询 Procscan 违规事件列表，`include_all=true` 返回全量事件 |
+| `GET` | `/api/procscan-violations` | 查询 Procscan 违规事件列表，`include_all=true` 返回全量事件；`page`、`keyword`、`time_range` 返回分页结果 |
 | `GET` | `/api/procscan-violations/:namespace` | 按 namespace 查询 Procscan 事件 |
 | `DELETE` | `/api/procscan-violations/id/:id` | 按 id 删除 Procscan 事件 |
 | `DELETE` | `/api/procscan-violations/:namespace` | 按 namespace 删除 Procscan 事件 |
@@ -409,12 +413,12 @@ docker run --rm -p 8080:8080 sealos-complik-admin
 | `POST` | `/api/bans` | 创建封禁记录 |
 | `POST` | `/api/bans/upload` | 上传截图并创建封禁记录 |
 | `GET` | `/api/bans/screenshots` | admin 代理预览封禁截图 |
-| `GET` | `/api/bans` | 查询封禁记录列表 |
+| `GET` | `/api/bans` | 查询封禁记录列表；`page`、`keyword`、`operator_name` 返回分页结果 |
 | `GET` | `/api/bans/:namespace` | 按 namespace 查询封禁记录 |
 | `DELETE` | `/api/bans/id/:id` | 按 id 删除封禁记录 |
 | `GET` | `/api/namespaces/:namespace/ban-status` | 查询 namespace 是否处于封禁状态 |
 | `POST` | `/api/unbans` | 创建解封记录 |
-| `GET` | `/api/unbans` | 查询解封记录列表 |
+| `GET` | `/api/unbans` | 查询解封记录列表；`page`、`keyword`、`operator_name` 返回分页结果 |
 | `GET` | `/api/unbans/:namespace` | 按 namespace 查询解封记录 |
 | `DELETE` | `/api/unbans/id/:id` | 按 id 删除解封记录 |
 

--- a/sealos-complik-admin/internal/modules/ban/dto.go
+++ b/sealos-complik-admin/internal/modules/ban/dto.go
@@ -1,6 +1,10 @@
 package ban
 
-import "time"
+import (
+	"time"
+
+	"sealos-complik-admin/internal/modules/pagequery"
+)
 
 type BanNamespaceRequest struct {
 	Namespace string `uri:"namespace" binding:"required,max=255"`
@@ -12,6 +16,12 @@ type BanIDRequest struct {
 
 type BanScreenshotQueryRequest struct {
 	URL string `form:"url" binding:"required,max=2048"`
+}
+
+type ListBansQueryRequest struct {
+	Page         int    `form:"page"`
+	Keyword      string `form:"keyword"`
+	OperatorName string `form:"operator_name"`
 }
 
 type CreateBanRequest struct {
@@ -45,3 +55,5 @@ type BanResponse struct {
 type BanStatusResponse struct {
 	Banned bool `json:"banned"`
 }
+
+type PaginatedBanResponse = pagequery.PaginatedResponse[BanResponse]

--- a/sealos-complik-admin/internal/modules/ban/handler.go
+++ b/sealos-complik-admin/internal/modules/ban/handler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 type Handler struct {
@@ -141,7 +142,39 @@ func (h *Handler) GetBans(c *gin.Context) {
 
 // ListBans handles listing all ban records.
 func (h *Handler) ListBans(c *gin.Context) {
+	if pagequery.HasPage(c.Query("page")) {
+		h.ListBansPage(c)
+		return
+	}
+
 	resp, err := h.service.ListBans(c.Request.Context())
+	if err != nil {
+		h.respondWithServiceError(c, err, "failed to list bans")
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+func (h *Handler) ListBansPage(c *gin.Context) {
+	var req ListBansQueryRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid request query",
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	options, err := pagequery.NewOptions(req.Page)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid page query",
+		})
+		return
+	}
+
+	resp, err := h.service.ListBansPage(c.Request.Context(), options, req.Keyword, req.OperatorName)
 	if err != nil {
 		h.respondWithServiceError(c, err, "failed to list bans")
 		return

--- a/sealos-complik-admin/internal/modules/ban/handler.go
+++ b/sealos-complik-admin/internal/modules/ban/handler.go
@@ -163,6 +163,7 @@ func (h *Handler) ListBansPage(c *gin.Context) {
 			"message": "invalid request query",
 			"error":   err.Error(),
 		})
+
 		return
 	}
 

--- a/sealos-complik-admin/internal/modules/ban/repository.go
+++ b/sealos-complik-admin/internal/modules/ban/repository.go
@@ -72,12 +72,14 @@ func (r *Repository) ListBansPage(
 	operatorName string,
 ) ([]Ban, int64, error) {
 	var total int64
+
 	countQuery := r.buildListQuery(ctx, keyword, operatorName)
 	if err := countQuery.Model(&Ban{}).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 
 	var bans []Ban
+
 	query := r.buildListQuery(ctx, keyword, operatorName)
 	if err := query.
 		Order("ban_start_time DESC, id DESC").
@@ -90,12 +92,17 @@ func (r *Repository) ListBansPage(
 	return bans, total, nil
 }
 
-func (r *Repository) buildListQuery(ctx context.Context, keyword string, operatorName string) *gorm.DB {
+func (r *Repository) buildListQuery(
+	ctx context.Context,
+	keyword string,
+	operatorName string,
+) *gorm.DB {
 	query := r.db.WithContext(ctx).Model(&Ban{})
 	if strings.TrimSpace(keyword) != "" {
 		value := "%" + strings.ToLower(strings.TrimSpace(keyword)) + "%"
 		query = query.Where("LOWER(namespace) LIKE ?", value)
 	}
+
 	if strings.TrimSpace(operatorName) != "" {
 		query = query.Where("operator_name = ?", strings.TrimSpace(operatorName))
 	}

--- a/sealos-complik-admin/internal/modules/ban/repository.go
+++ b/sealos-complik-admin/internal/modules/ban/repository.go
@@ -3,9 +3,11 @@ package ban
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 const (
@@ -61,6 +63,44 @@ func (r *Repository) ListBans(ctx context.Context) ([]Ban, error) {
 	}
 
 	return bans, nil
+}
+
+func (r *Repository) ListBansPage(
+	ctx context.Context,
+	options pagequery.Options,
+	keyword string,
+	operatorName string,
+) ([]Ban, int64, error) {
+	var total int64
+	countQuery := r.buildListQuery(ctx, keyword, operatorName)
+	if err := countQuery.Model(&Ban{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var bans []Ban
+	query := r.buildListQuery(ctx, keyword, operatorName)
+	if err := query.
+		Order("ban_start_time DESC, id DESC").
+		Limit(options.PageSize).
+		Offset(options.Offset()).
+		Find(&bans).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return bans, total, nil
+}
+
+func (r *Repository) buildListQuery(ctx context.Context, keyword string, operatorName string) *gorm.DB {
+	query := r.db.WithContext(ctx).Model(&Ban{})
+	if strings.TrimSpace(keyword) != "" {
+		value := "%" + strings.ToLower(strings.TrimSpace(keyword)) + "%"
+		query = query.Where("LOWER(namespace) LIKE ?", value)
+	}
+	if strings.TrimSpace(operatorName) != "" {
+		query = query.Where("operator_name = ?", strings.TrimSpace(operatorName))
+	}
+
+	return query
 }
 
 // DeleteBanByID deletes a single ban record by id.

--- a/sealos-complik-admin/internal/modules/ban/services.go
+++ b/sealos-complik-admin/internal/modules/ban/services.go
@@ -169,6 +169,7 @@ func (s *Service) ListBansPage(
 	}
 
 	response := pagequery.NewPaginatedResponse(responses, total, options)
+
 	return &response, nil
 }
 

--- a/sealos-complik-admin/internal/modules/ban/services.go
+++ b/sealos-complik-admin/internal/modules/ban/services.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 var (
@@ -149,6 +150,26 @@ func (s *Service) ListBans(ctx context.Context) ([]BanResponse, error) {
 	}
 
 	return responses, nil
+}
+
+func (s *Service) ListBansPage(
+	ctx context.Context,
+	options pagequery.Options,
+	keyword string,
+	operatorName string,
+) (*PaginatedBanResponse, error) {
+	bans, total, err := s.repository.ListBansPage(ctx, options, keyword, operatorName)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]BanResponse, 0, len(bans))
+	for i := range bans {
+		responses = append(responses, *toBanResponse(&bans[i]))
+	}
+
+	response := pagequery.NewPaginatedResponse(responses, total, options)
+	return &response, nil
 }
 
 // GetBanStatus returns whether the given namespace is currently banned.

--- a/sealos-complik-admin/internal/modules/commitment/dto.go
+++ b/sealos-complik-admin/internal/modules/commitment/dto.go
@@ -1,6 +1,10 @@
 package commitment
 
-import "time"
+import (
+	"time"
+
+	"sealos-complik-admin/internal/modules/pagequery"
+)
 
 type CommitmentNamespaceRequest struct {
 	Namespace string `uri:"namespace" binding:"required,max=255"`
@@ -16,6 +20,11 @@ type UploadCommitmentRequest struct {
 	Namespace string `form:"namespace" binding:"required,max=255"`
 }
 
+type ListCommitmentsQueryRequest struct {
+	Page    int    `form:"page"`
+	Keyword string `form:"keyword"`
+}
+
 type UpdateCommitmentRequest struct {
 	FileName string `json:"file_name" binding:"required,max=255"`
 	FileURL  string `json:"file_url"  binding:"required,max=512"`
@@ -28,3 +37,5 @@ type CommitmentResponse struct {
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
+
+type PaginatedCommitmentResponse = pagequery.PaginatedResponse[CommitmentResponse]

--- a/sealos-complik-admin/internal/modules/commitment/handler.go
+++ b/sealos-complik-admin/internal/modules/commitment/handler.go
@@ -169,6 +169,7 @@ func (h *Handler) ListCommitmentsPage(c *gin.Context) {
 			"message": "invalid request query",
 			"error":   err.Error(),
 		})
+
 		return
 	}
 

--- a/sealos-complik-admin/internal/modules/commitment/handler.go
+++ b/sealos-complik-admin/internal/modules/commitment/handler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 type Handler struct {
@@ -147,7 +148,39 @@ func (h *Handler) GetCommitment(c *gin.Context) {
 
 // ListCommitments handles listing all commitments.
 func (h *Handler) ListCommitments(c *gin.Context) {
+	if pagequery.HasPage(c.Query("page")) {
+		h.ListCommitmentsPage(c)
+		return
+	}
+
 	resp, err := h.service.ListCommitments(c.Request.Context())
+	if err != nil {
+		h.respondWithServiceError(c, err, "failed to list commitments")
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+func (h *Handler) ListCommitmentsPage(c *gin.Context) {
+	var req ListCommitmentsQueryRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid request query",
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	options, err := pagequery.NewOptions(req.Page)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid page query",
+		})
+		return
+	}
+
+	resp, err := h.service.ListCommitmentsPage(c.Request.Context(), options, req.Keyword)
 	if err != nil {
 		h.respondWithServiceError(c, err, "failed to list commitments")
 		return

--- a/sealos-complik-admin/internal/modules/commitment/repository.go
+++ b/sealos-complik-admin/internal/modules/commitment/repository.go
@@ -53,12 +53,14 @@ func (r *Repository) ListCommitmentsPage(
 	keyword string,
 ) ([]Commitment, int64, error) {
 	var total int64
+
 	countQuery := r.buildListQuery(ctx, keyword)
 	if err := countQuery.Model(&Commitment{}).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 
 	var commitments []Commitment
+
 	query := r.buildListQuery(ctx, keyword)
 	if err := query.
 		Order("updated_at DESC, id DESC").

--- a/sealos-complik-admin/internal/modules/commitment/repository.go
+++ b/sealos-complik-admin/internal/modules/commitment/repository.go
@@ -2,8 +2,10 @@ package commitment
 
 import (
 	"context"
+	"strings"
 
 	"gorm.io/gorm"
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 type Repository struct {
@@ -43,6 +45,40 @@ func (r *Repository) ListCommitments(ctx context.Context) ([]Commitment, error) 
 	}
 
 	return commitments, nil
+}
+
+func (r *Repository) ListCommitmentsPage(
+	ctx context.Context,
+	options pagequery.Options,
+	keyword string,
+) ([]Commitment, int64, error) {
+	var total int64
+	countQuery := r.buildListQuery(ctx, keyword)
+	if err := countQuery.Model(&Commitment{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var commitments []Commitment
+	query := r.buildListQuery(ctx, keyword)
+	if err := query.
+		Order("updated_at DESC, id DESC").
+		Limit(options.PageSize).
+		Offset(options.Offset()).
+		Find(&commitments).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return commitments, total, nil
+}
+
+func (r *Repository) buildListQuery(ctx context.Context, keyword string) *gorm.DB {
+	query := r.db.WithContext(ctx).Model(&Commitment{})
+	if strings.TrimSpace(keyword) != "" {
+		value := "%" + strings.ToLower(strings.TrimSpace(keyword)) + "%"
+		query = query.Where("LOWER(namespace) LIKE ?", value)
+	}
+
+	return query
 }
 
 // UpdateCommitment updates an existing commitment record.

--- a/sealos-complik-admin/internal/modules/commitment/services.go
+++ b/sealos-complik-admin/internal/modules/commitment/services.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 var (
@@ -149,6 +150,25 @@ func (s *Service) ListCommitments(ctx context.Context) ([]CommitmentResponse, er
 	}
 
 	return responses, nil
+}
+
+func (s *Service) ListCommitmentsPage(
+	ctx context.Context,
+	options pagequery.Options,
+	keyword string,
+) (*PaginatedCommitmentResponse, error) {
+	commitments, total, err := s.repository.ListCommitmentsPage(ctx, options, keyword)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]CommitmentResponse, 0, len(commitments))
+	for i := range commitments {
+		responses = append(responses, *toCommitmentResponse(&commitments[i]))
+	}
+
+	response := pagequery.NewPaginatedResponse(responses, total, options)
+	return &response, nil
 }
 
 // UploadCommitment uploads commitment PDF and upserts commitment metadata by namespace.

--- a/sealos-complik-admin/internal/modules/commitment/services.go
+++ b/sealos-complik-admin/internal/modules/commitment/services.go
@@ -168,6 +168,7 @@ func (s *Service) ListCommitmentsPage(
 	}
 
 	response := pagequery.NewPaginatedResponse(responses, total, options)
+
 	return &response, nil
 }
 

--- a/sealos-complik-admin/internal/modules/complikviolation/dto.go
+++ b/sealos-complik-admin/internal/modules/complikviolation/dto.go
@@ -3,6 +3,8 @@ package complikviolation
 import (
 	"encoding/json"
 	"time"
+
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 type NamespaceRequest struct {
@@ -61,3 +63,5 @@ type ViolationResponse struct {
 type ViolationStatusResponse struct {
 	Violated bool `json:"violated"`
 }
+
+type PaginatedViolationResponse = pagequery.PaginatedResponse[ViolationResponse]

--- a/sealos-complik-admin/internal/modules/complikviolation/handler.go
+++ b/sealos-complik-admin/internal/modules/complikviolation/handler.go
@@ -116,6 +116,7 @@ func (h *Handler) ListViolations(c *gin.Context) {
 		}
 
 		c.JSON(http.StatusOK, resp)
+
 		return
 	}
 

--- a/sealos-complik-admin/internal/modules/complikviolation/handler.go
+++ b/sealos-complik-admin/internal/modules/complikviolation/handler.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"sealos-complik-admin/internal/modules/violationquery"
 )
 
 type Handler struct {
@@ -101,6 +103,22 @@ func (h *Handler) ListViolations(c *gin.Context) {
 		return
 	}
 
+	if hasPageQuery(c) {
+		options, ok := bindListOptionsQuery(c, includeAll)
+		if !ok {
+			return
+		}
+
+		resp, err := h.service.ListViolationsPage(c.Request.Context(), options)
+		if err != nil {
+			h.respondWithServiceError(c, err, "failed to list complik violations")
+			return
+		}
+
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+
 	resp, err := h.service.ListViolations(c.Request.Context(), includeAll)
 	if err != nil {
 		h.respondWithServiceError(c, err, "failed to list complik violations")
@@ -156,6 +174,55 @@ func bindIncludeAllQuery(c *gin.Context) (bool, bool) {
 	}
 
 	return includeAll, true
+}
+
+func hasPageQuery(c *gin.Context) bool {
+	raw := strings.TrimSpace(c.Query("page"))
+	return raw != ""
+}
+
+func bindListOptionsQuery(c *gin.Context, includeAll bool) (violationquery.ListOptions, bool) {
+	page, ok := bindPageQuery(c)
+	if !ok {
+		return violationquery.ListOptions{}, false
+	}
+
+	options, err := violationquery.NewListOptions(violationquery.ListInput{
+		IncludeAll: includeAll,
+		Page:       page,
+		Keyword:    c.Query("keyword"),
+		TimeRange:  c.Query("time_range"),
+		Now:        time.Now(),
+	})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid violation list query",
+			"error":   err.Error(),
+		})
+
+		return violationquery.ListOptions{}, false
+	}
+
+	return options, true
+}
+
+func bindPageQuery(c *gin.Context) (int, bool) {
+	raw := strings.TrimSpace(c.Query("page"))
+	if raw == "" {
+		return 1, true
+	}
+
+	page, err := strconv.Atoi(raw)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid page query",
+			"error":   err.Error(),
+		})
+
+		return 0, false
+	}
+
+	return page, true
 }
 
 func (h *Handler) respondWithServiceError(c *gin.Context, err error, fallbackMessage string) {

--- a/sealos-complik-admin/internal/modules/complikviolation/repository.go
+++ b/sealos-complik-admin/internal/modules/complikviolation/repository.go
@@ -2,8 +2,10 @@ package complikviolation
 
 import (
 	"context"
+	"strings"
 
 	"gorm.io/gorm"
+	"sealos-complik-admin/internal/modules/violationquery"
 )
 
 type Repository struct {
@@ -75,16 +77,63 @@ func (r *Repository) ListViolations(
 ) ([]ComplikViolationEvent, error) {
 	var violations []ComplikViolationEvent
 
-	query := r.db.WithContext(ctx)
-	if !includeAll {
-		query = query.Where(complikEffectiveViolationCondition)
-	}
+	query := r.buildListQuery(ctx, includeAll, violationquery.ListOptions{})
 
 	if err := query.Order("detected_at DESC, id DESC").Find(&violations).Error; err != nil {
 		return nil, err
 	}
 
 	return violations, nil
+}
+
+func (r *Repository) ListViolationsPage(
+	ctx context.Context,
+	options violationquery.ListOptions,
+) ([]ComplikViolationEvent, int64, error) {
+	var total int64
+	countQuery := r.buildListQuery(ctx, options.IncludeAll, options)
+	if err := countQuery.Model(&ComplikViolationEvent{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var violations []ComplikViolationEvent
+	query := r.buildListQuery(ctx, options.IncludeAll, options)
+	if err := query.
+		Order("detected_at DESC, id DESC").
+		Limit(options.PageSize).
+		Offset(options.Offset()).
+		Find(&violations).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return violations, total, nil
+}
+
+func (r *Repository) buildListQuery(
+	ctx context.Context,
+	includeAll bool,
+	options violationquery.ListOptions,
+) *gorm.DB {
+	query := r.db.WithContext(ctx).Model(&ComplikViolationEvent{})
+	if !includeAll {
+		query = query.Where(complikEffectiveViolationCondition)
+	}
+	if options.StartTime != nil {
+		query = query.Where("detected_at >= ?", *options.StartTime)
+	}
+	if options.Keyword != "" {
+		keyword := "%" + strings.ToLower(options.Keyword) + "%"
+		query = query.Where(
+			r.db.Where("LOWER(namespace) LIKE ?", keyword).
+				Or("LOWER(detector_name) LIKE ?", keyword).
+				Or("LOWER(resource_name) LIKE ?", keyword).
+				Or("LOWER(host) LIKE ?", keyword).
+				Or("LOWER(url) LIKE ?", keyword).
+				Or("LOWER(description) LIKE ?", keyword),
+		)
+	}
+
+	return query
 }
 
 func (r *Repository) DeleteViolationByID(ctx context.Context, id uint64) error {

--- a/sealos-complik-admin/internal/modules/complikviolation/repository.go
+++ b/sealos-complik-admin/internal/modules/complikviolation/repository.go
@@ -91,12 +91,14 @@ func (r *Repository) ListViolationsPage(
 	options violationquery.ListOptions,
 ) ([]ComplikViolationEvent, int64, error) {
 	var total int64
+
 	countQuery := r.buildListQuery(ctx, options.IncludeAll, options)
 	if err := countQuery.Model(&ComplikViolationEvent{}).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 
 	var violations []ComplikViolationEvent
+
 	query := r.buildListQuery(ctx, options.IncludeAll, options)
 	if err := query.
 		Order("detected_at DESC, id DESC").
@@ -118,9 +120,11 @@ func (r *Repository) buildListQuery(
 	if !includeAll {
 		query = query.Where(complikEffectiveViolationCondition)
 	}
+
 	if options.StartTime != nil {
 		query = query.Where("detected_at >= ?", *options.StartTime)
 	}
+
 	if options.Keyword != "" {
 		keyword := "%" + strings.ToLower(options.Keyword) + "%"
 		query = query.Where(

--- a/sealos-complik-admin/internal/modules/complikviolation/services.go
+++ b/sealos-complik-admin/internal/modules/complikviolation/services.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"sealos-complik-admin/internal/modules/pagequery"
+	"sealos-complik-admin/internal/modules/violationquery"
 )
 
 var (
@@ -143,6 +145,28 @@ func (s *Service) ListViolations(
 	}
 
 	return responses, nil
+}
+
+func (s *Service) ListViolationsPage(
+	ctx context.Context,
+	options violationquery.ListOptions,
+) (*PaginatedViolationResponse, error) {
+	violations, total, err := s.repository.ListViolationsPage(ctx, options)
+	if err != nil {
+		return nil, translateRepositoryError(err)
+	}
+
+	responses := make([]ViolationResponse, 0, len(violations))
+	for i := range violations {
+		if !options.IncludeAll && !isEffectiveViolation(&violations[i]) {
+			continue
+		}
+
+		responses = append(responses, *toViolationResponse(&violations[i]))
+	}
+
+	response := pagequery.NewPaginatedResponse(responses, total, options.Options)
+	return &response, nil
 }
 
 func (s *Service) GetViolationStatus(

--- a/sealos-complik-admin/internal/modules/complikviolation/services.go
+++ b/sealos-complik-admin/internal/modules/complikviolation/services.go
@@ -158,10 +158,6 @@ func (s *Service) ListViolationsPage(
 
 	responses := make([]ViolationResponse, 0, len(violations))
 	for i := range violations {
-		if !options.IncludeAll && !isEffectiveViolation(&violations[i]) {
-			continue
-		}
-
 		responses = append(responses, *toViolationResponse(&violations[i]))
 	}
 

--- a/sealos-complik-admin/internal/modules/complikviolation/services.go
+++ b/sealos-complik-admin/internal/modules/complikviolation/services.go
@@ -166,6 +166,7 @@ func (s *Service) ListViolationsPage(
 	}
 
 	response := pagequery.NewPaginatedResponse(responses, total, options.Options)
+
 	return &response, nil
 }
 

--- a/sealos-complik-admin/internal/modules/pagequery/query.go
+++ b/sealos-complik-admin/internal/modules/pagequery/query.go
@@ -1,0 +1,80 @@
+package pagequery
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+const FixedPageSize = 10
+
+var ErrInvalidQuery = errors.New("invalid page query")
+
+type Options struct {
+	Page     int
+	PageSize int
+}
+
+type Input struct {
+	Page    int
+	Keyword string
+}
+
+type PaginatedResponse[T any] struct {
+	List       []T   `json:"list"`
+	Total      int64 `json:"total"`
+	Page       int   `json:"page"`
+	PageSize   int   `json:"page_size"`
+	TotalPages int   `json:"total_pages"`
+}
+
+func NewOptions(page int) (Options, error) {
+	if page == 0 {
+		page = 1
+	}
+	if page < 1 {
+		return Options{}, ErrInvalidQuery
+	}
+
+	return Options{
+		Page:     page,
+		PageSize: FixedPageSize,
+	}, nil
+}
+
+func HasPage(raw string) bool {
+	return strings.TrimSpace(raw) != ""
+}
+
+func ParsePage(raw string) (int, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return 0, nil
+	}
+
+	page, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0, ErrInvalidQuery
+	}
+
+	return page, nil
+}
+
+func (o Options) Offset() int {
+	return (o.Page - 1) * o.PageSize
+}
+
+func NewPaginatedResponse[T any](list []T, total int64, options Options) PaginatedResponse[T] {
+	totalPages := int(total / int64(options.PageSize))
+	if total%int64(options.PageSize) > 0 {
+		totalPages++
+	}
+
+	return PaginatedResponse[T]{
+		List:       list,
+		Total:      total,
+		Page:       options.Page,
+		PageSize:   options.PageSize,
+		TotalPages: totalPages,
+	}
+}

--- a/sealos-complik-admin/internal/modules/pagequery/query.go
+++ b/sealos-complik-admin/internal/modules/pagequery/query.go
@@ -32,6 +32,7 @@ func NewOptions(page int) (Options, error) {
 	if page == 0 {
 		page = 1
 	}
+
 	if page < 1 {
 		return Options{}, ErrInvalidQuery
 	}

--- a/sealos-complik-admin/internal/modules/pagequery/query_test.go
+++ b/sealos-complik-admin/internal/modules/pagequery/query_test.go
@@ -1,0 +1,55 @@
+package pagequery
+
+import "testing"
+
+func TestNewOptionsUsesFixedPageSize(t *testing.T) {
+	options, err := NewOptions(3)
+	if err != nil {
+		t.Fatalf("NewOptions() error = %v", err)
+	}
+
+	if options.Page != 3 {
+		t.Fatalf("Page = %d, want 3", options.Page)
+	}
+	if options.PageSize != FixedPageSize {
+		t.Fatalf("PageSize = %d, want %d", options.PageSize, FixedPageSize)
+	}
+	if options.Offset() != 20 {
+		t.Fatalf("Offset() = %d, want 20", options.Offset())
+	}
+}
+
+func TestNewOptionsDefaultsPage(t *testing.T) {
+	options, err := NewOptions(0)
+	if err != nil {
+		t.Fatalf("NewOptions() error = %v", err)
+	}
+
+	if options.Page != 1 {
+		t.Fatalf("Page = %d, want 1", options.Page)
+	}
+}
+
+func TestNewOptionsRejectsInvalidPage(t *testing.T) {
+	_, err := NewOptions(-1)
+	if err == nil {
+		t.Fatal("NewOptions() error = nil, want error")
+	}
+}
+
+func TestPaginatedResponseComputesTotalPages(t *testing.T) {
+	response := NewPaginatedResponse([]string{"a", "b"}, 21, Options{
+		Page:     3,
+		PageSize: FixedPageSize,
+	})
+
+	if response.TotalPages != 3 {
+		t.Fatalf("TotalPages = %d, want 3", response.TotalPages)
+	}
+	if response.Total != 21 {
+		t.Fatalf("Total = %d, want 21", response.Total)
+	}
+	if len(response.List) != 2 {
+		t.Fatalf("len(List) = %d, want 2", len(response.List))
+	}
+}

--- a/sealos-complik-admin/internal/modules/pagequery/query_test.go
+++ b/sealos-complik-admin/internal/modules/pagequery/query_test.go
@@ -1,9 +1,13 @@
-package pagequery
+package pagequery_test
 
-import "testing"
+import (
+	"testing"
+
+	"sealos-complik-admin/internal/modules/pagequery"
+)
 
 func TestNewOptionsUsesFixedPageSize(t *testing.T) {
-	options, err := NewOptions(3)
+	options, err := pagequery.NewOptions(3)
 	if err != nil {
 		t.Fatalf("NewOptions() error = %v", err)
 	}
@@ -11,16 +15,18 @@ func TestNewOptionsUsesFixedPageSize(t *testing.T) {
 	if options.Page != 3 {
 		t.Fatalf("Page = %d, want 3", options.Page)
 	}
-	if options.PageSize != FixedPageSize {
-		t.Fatalf("PageSize = %d, want %d", options.PageSize, FixedPageSize)
+
+	if options.PageSize != pagequery.FixedPageSize {
+		t.Fatalf("PageSize = %d, want %d", options.PageSize, pagequery.FixedPageSize)
 	}
+
 	if options.Offset() != 20 {
 		t.Fatalf("Offset() = %d, want 20", options.Offset())
 	}
 }
 
 func TestNewOptionsDefaultsPage(t *testing.T) {
-	options, err := NewOptions(0)
+	options, err := pagequery.NewOptions(0)
 	if err != nil {
 		t.Fatalf("NewOptions() error = %v", err)
 	}
@@ -31,24 +37,26 @@ func TestNewOptionsDefaultsPage(t *testing.T) {
 }
 
 func TestNewOptionsRejectsInvalidPage(t *testing.T) {
-	_, err := NewOptions(-1)
+	_, err := pagequery.NewOptions(-1)
 	if err == nil {
 		t.Fatal("NewOptions() error = nil, want error")
 	}
 }
 
 func TestPaginatedResponseComputesTotalPages(t *testing.T) {
-	response := NewPaginatedResponse([]string{"a", "b"}, 21, Options{
+	response := pagequery.NewPaginatedResponse([]string{"a", "b"}, 21, pagequery.Options{
 		Page:     3,
-		PageSize: FixedPageSize,
+		PageSize: pagequery.FixedPageSize,
 	})
 
 	if response.TotalPages != 3 {
 		t.Fatalf("TotalPages = %d, want 3", response.TotalPages)
 	}
+
 	if response.Total != 21 {
 		t.Fatalf("Total = %d, want 21", response.Total)
 	}
+
 	if len(response.List) != 2 {
 		t.Fatalf("len(List) = %d, want 2", len(response.List))
 	}

--- a/sealos-complik-admin/internal/modules/procscanviolation/dto.go
+++ b/sealos-complik-admin/internal/modules/procscanviolation/dto.go
@@ -3,6 +3,8 @@ package procscanviolation
 import (
 	"encoding/json"
 	"time"
+
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 type NamespaceRequest struct {
@@ -55,3 +57,5 @@ type ViolationResponse struct {
 type ViolationStatusResponse struct {
 	Violated bool `json:"violated"`
 }
+
+type PaginatedViolationResponse = pagequery.PaginatedResponse[ViolationResponse]

--- a/sealos-complik-admin/internal/modules/procscanviolation/handler.go
+++ b/sealos-complik-admin/internal/modules/procscanviolation/handler.go
@@ -116,6 +116,7 @@ func (h *Handler) ListViolations(c *gin.Context) {
 		}
 
 		c.JSON(http.StatusOK, resp)
+
 		return
 	}
 

--- a/sealos-complik-admin/internal/modules/procscanviolation/handler.go
+++ b/sealos-complik-admin/internal/modules/procscanviolation/handler.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"sealos-complik-admin/internal/modules/violationquery"
 )
 
 type Handler struct {
@@ -101,6 +103,22 @@ func (h *Handler) ListViolations(c *gin.Context) {
 		return
 	}
 
+	if hasPageQuery(c) {
+		options, ok := bindListOptionsQuery(c, includeAll)
+		if !ok {
+			return
+		}
+
+		resp, err := h.service.ListViolationsPage(c.Request.Context(), options)
+		if err != nil {
+			h.respondWithServiceError(c, err, "failed to list procscan violations")
+			return
+		}
+
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+
 	resp, err := h.service.ListViolations(c.Request.Context(), includeAll)
 	if err != nil {
 		h.respondWithServiceError(c, err, "failed to list procscan violations")
@@ -156,6 +174,55 @@ func bindIncludeAllQuery(c *gin.Context) (bool, bool) {
 	}
 
 	return includeAll, true
+}
+
+func hasPageQuery(c *gin.Context) bool {
+	raw := strings.TrimSpace(c.Query("page"))
+	return raw != ""
+}
+
+func bindListOptionsQuery(c *gin.Context, includeAll bool) (violationquery.ListOptions, bool) {
+	page, ok := bindPageQuery(c)
+	if !ok {
+		return violationquery.ListOptions{}, false
+	}
+
+	options, err := violationquery.NewListOptions(violationquery.ListInput{
+		IncludeAll: includeAll,
+		Page:       page,
+		Keyword:    c.Query("keyword"),
+		TimeRange:  c.Query("time_range"),
+		Now:        time.Now(),
+	})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid violation list query",
+			"error":   err.Error(),
+		})
+
+		return violationquery.ListOptions{}, false
+	}
+
+	return options, true
+}
+
+func bindPageQuery(c *gin.Context) (int, bool) {
+	raw := strings.TrimSpace(c.Query("page"))
+	if raw == "" {
+		return 1, true
+	}
+
+	page, err := strconv.Atoi(raw)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid page query",
+			"error":   err.Error(),
+		})
+
+		return 0, false
+	}
+
+	return page, true
 }
 
 func (h *Handler) respondWithServiceError(c *gin.Context, err error, fallbackMessage string) {

--- a/sealos-complik-admin/internal/modules/procscanviolation/repository.go
+++ b/sealos-complik-admin/internal/modules/procscanviolation/repository.go
@@ -95,12 +95,14 @@ func (r *Repository) ListViolationsPage(
 	options violationquery.ListOptions,
 ) ([]ProcscanViolationEvent, int64, error) {
 	var total int64
+
 	countQuery := r.buildListQuery(ctx, options.IncludeAll, options)
 	if err := countQuery.Model(&ProcscanViolationEvent{}).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 
 	var violations []ProcscanViolationEvent
+
 	query := r.buildListQuery(ctx, options.IncludeAll, options)
 	if err := query.
 		Order("detected_at DESC, id DESC").
@@ -122,9 +124,11 @@ func (r *Repository) buildListQuery(
 	if !includeAll {
 		query = query.Where(procscanEffectiveViolationCondition)
 	}
+
 	if options.StartTime != nil {
 		query = query.Where("detected_at >= ?", *options.StartTime)
 	}
+
 	if options.Keyword != "" {
 		keyword := "%" + strings.ToLower(options.Keyword) + "%"
 		query = query.Where(

--- a/sealos-complik-admin/internal/modules/procscanviolation/repository.go
+++ b/sealos-complik-admin/internal/modules/procscanviolation/repository.go
@@ -2,8 +2,10 @@ package procscanviolation
 
 import (
 	"context"
+	"strings"
 
 	"gorm.io/gorm"
+	"sealos-complik-admin/internal/modules/violationquery"
 )
 
 type Repository struct {
@@ -79,16 +81,64 @@ func (r *Repository) ListViolations(
 ) ([]ProcscanViolationEvent, error) {
 	var violations []ProcscanViolationEvent
 
-	query := r.db.WithContext(ctx)
-	if !includeAll {
-		query = query.Where(procscanEffectiveViolationCondition)
-	}
+	query := r.buildListQuery(ctx, includeAll, violationquery.ListOptions{})
 
 	if err := query.Order("detected_at DESC, id DESC").Find(&violations).Error; err != nil {
 		return nil, err
 	}
 
 	return violations, nil
+}
+
+func (r *Repository) ListViolationsPage(
+	ctx context.Context,
+	options violationquery.ListOptions,
+) ([]ProcscanViolationEvent, int64, error) {
+	var total int64
+	countQuery := r.buildListQuery(ctx, options.IncludeAll, options)
+	if err := countQuery.Model(&ProcscanViolationEvent{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var violations []ProcscanViolationEvent
+	query := r.buildListQuery(ctx, options.IncludeAll, options)
+	if err := query.
+		Order("detected_at DESC, id DESC").
+		Limit(options.PageSize).
+		Offset(options.Offset()).
+		Find(&violations).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return violations, total, nil
+}
+
+func (r *Repository) buildListQuery(
+	ctx context.Context,
+	includeAll bool,
+	options violationquery.ListOptions,
+) *gorm.DB {
+	query := r.db.WithContext(ctx).Model(&ProcscanViolationEvent{})
+	if !includeAll {
+		query = query.Where(procscanEffectiveViolationCondition)
+	}
+	if options.StartTime != nil {
+		query = query.Where("detected_at >= ?", *options.StartTime)
+	}
+	if options.Keyword != "" {
+		keyword := "%" + strings.ToLower(options.Keyword) + "%"
+		query = query.Where(
+			r.db.Where("LOWER(namespace) LIKE ?", keyword).
+				Or("LOWER(pod_name) LIKE ?", keyword).
+				Or("LOWER(node_name) LIKE ?", keyword).
+				Or("LOWER(process_name) LIKE ?", keyword).
+				Or("LOWER(process_command) LIKE ?", keyword).
+				Or("LOWER(match_rule) LIKE ?", keyword).
+				Or("LOWER(message) LIKE ?", keyword),
+		)
+	}
+
+	return query
 }
 
 func (r *Repository) DeleteViolationByID(ctx context.Context, id uint64) error {

--- a/sealos-complik-admin/internal/modules/procscanviolation/services.go
+++ b/sealos-complik-admin/internal/modules/procscanviolation/services.go
@@ -145,10 +145,6 @@ func (s *Service) ListViolationsPage(
 
 	responses := make([]ViolationResponse, 0, len(violations))
 	for i := range violations {
-		if !options.IncludeAll && !isEffectiveViolation(&violations[i]) {
-			continue
-		}
-
 		responses = append(responses, *toViolationResponse(&violations[i]))
 	}
 

--- a/sealos-complik-admin/internal/modules/procscanviolation/services.go
+++ b/sealos-complik-admin/internal/modules/procscanviolation/services.go
@@ -153,6 +153,7 @@ func (s *Service) ListViolationsPage(
 	}
 
 	response := pagequery.NewPaginatedResponse(responses, total, options.Options)
+
 	return &response, nil
 }
 

--- a/sealos-complik-admin/internal/modules/procscanviolation/services.go
+++ b/sealos-complik-admin/internal/modules/procscanviolation/services.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"sealos-complik-admin/internal/modules/pagequery"
+	"sealos-complik-admin/internal/modules/violationquery"
 )
 
 var (
@@ -130,6 +132,28 @@ func (s *Service) ListViolations(
 	}
 
 	return responses, nil
+}
+
+func (s *Service) ListViolationsPage(
+	ctx context.Context,
+	options violationquery.ListOptions,
+) (*PaginatedViolationResponse, error) {
+	violations, total, err := s.repository.ListViolationsPage(ctx, options)
+	if err != nil {
+		return nil, translateRepositoryError(err)
+	}
+
+	responses := make([]ViolationResponse, 0, len(violations))
+	for i := range violations {
+		if !options.IncludeAll && !isEffectiveViolation(&violations[i]) {
+			continue
+		}
+
+		responses = append(responses, *toViolationResponse(&violations[i]))
+	}
+
+	response := pagequery.NewPaginatedResponse(responses, total, options.Options)
+	return &response, nil
 }
 
 func (s *Service) GetViolationStatus(

--- a/sealos-complik-admin/internal/modules/projectconfig/dto.go
+++ b/sealos-complik-admin/internal/modules/projectconfig/dto.go
@@ -3,6 +3,8 @@ package projectconfig
 import (
 	"encoding/json"
 	"time"
+
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 type ProjectConfigNameRequest struct {
@@ -11,6 +13,11 @@ type ProjectConfigNameRequest struct {
 
 type ProjectConfigTypeRequest struct {
 	ConfigType string `uri:"config_type" binding:"required,max=50"`
+}
+
+type ListProjectConfigsQueryRequest struct {
+	Page    int    `form:"page"`
+	Keyword string `form:"keyword"`
 }
 
 type CreateProjectConfigRequest struct {
@@ -35,3 +42,5 @@ type ProjectConfigResponse struct {
 	CreatedAt   time.Time       `json:"created_at"`
 	UpdatedAt   time.Time       `json:"updated_at"`
 }
+
+type PaginatedProjectConfigResponse = pagequery.PaginatedResponse[ProjectConfigResponse]

--- a/sealos-complik-admin/internal/modules/projectconfig/handler.go
+++ b/sealos-complik-admin/internal/modules/projectconfig/handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 type Handler struct {
@@ -121,7 +122,39 @@ func (h *Handler) GetProjectConfig(c *gin.Context) {
 
 // ListProjectConfigs handles listing all project configurations.
 func (h *Handler) ListProjectConfigs(c *gin.Context) {
+	if pagequery.HasPage(c.Query("page")) {
+		h.ListProjectConfigsPage(c)
+		return
+	}
+
 	resp, err := h.service.ListProjectConfigs(c.Request.Context())
+	if err != nil {
+		h.respondWithServiceError(c, err, "failed to list project configs")
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+func (h *Handler) ListProjectConfigsPage(c *gin.Context) {
+	var req ListProjectConfigsQueryRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid request query",
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	options, err := pagequery.NewOptions(req.Page)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid page query",
+		})
+		return
+	}
+
+	resp, err := h.service.ListProjectConfigsPage(c.Request.Context(), options, req.Keyword)
 	if err != nil {
 		h.respondWithServiceError(c, err, "failed to list project configs")
 		return

--- a/sealos-complik-admin/internal/modules/projectconfig/handler.go
+++ b/sealos-complik-admin/internal/modules/projectconfig/handler.go
@@ -143,6 +143,7 @@ func (h *Handler) ListProjectConfigsPage(c *gin.Context) {
 			"message": "invalid request query",
 			"error":   err.Error(),
 		})
+
 		return
 	}
 

--- a/sealos-complik-admin/internal/modules/projectconfig/repository.go
+++ b/sealos-complik-admin/internal/modules/projectconfig/repository.go
@@ -53,12 +53,14 @@ func (r *Repository) ListProjectConfigsPage(
 	keyword string,
 ) ([]ProjectConfig, int64, error) {
 	var total int64
+
 	countQuery := r.buildListQuery(ctx, keyword)
 	if err := countQuery.Model(&ProjectConfig{}).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 
 	var projectConfigs []ProjectConfig
+
 	query := r.buildListQuery(ctx, keyword)
 	if err := query.
 		Order("updated_at DESC, id DESC").

--- a/sealos-complik-admin/internal/modules/projectconfig/repository.go
+++ b/sealos-complik-admin/internal/modules/projectconfig/repository.go
@@ -2,8 +2,10 @@ package projectconfig
 
 import (
 	"context"
+	"strings"
 
 	"gorm.io/gorm"
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 type Repository struct {
@@ -43,6 +45,40 @@ func (r *Repository) ListProjectConfigs(ctx context.Context) ([]ProjectConfig, e
 	}
 
 	return projectConfigs, nil
+}
+
+func (r *Repository) ListProjectConfigsPage(
+	ctx context.Context,
+	options pagequery.Options,
+	keyword string,
+) ([]ProjectConfig, int64, error) {
+	var total int64
+	countQuery := r.buildListQuery(ctx, keyword)
+	if err := countQuery.Model(&ProjectConfig{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var projectConfigs []ProjectConfig
+	query := r.buildListQuery(ctx, keyword)
+	if err := query.
+		Order("updated_at DESC, id DESC").
+		Limit(options.PageSize).
+		Offset(options.Offset()).
+		Find(&projectConfigs).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return projectConfigs, total, nil
+}
+
+func (r *Repository) buildListQuery(ctx context.Context, keyword string) *gorm.DB {
+	query := r.db.WithContext(ctx).Model(&ProjectConfig{})
+	if strings.TrimSpace(keyword) != "" {
+		value := "%" + strings.ToLower(strings.TrimSpace(keyword)) + "%"
+		query = query.Where("LOWER(config_name) LIKE ?", value)
+	}
+
+	return query
 }
 
 // ListProjectConfigsByType returns project configurations filtered by config type.

--- a/sealos-complik-admin/internal/modules/projectconfig/services.go
+++ b/sealos-complik-admin/internal/modules/projectconfig/services.go
@@ -142,6 +142,7 @@ func (s *Service) ListProjectConfigsPage(
 	}
 
 	response := pagequery.NewPaginatedResponse(responses, total, options)
+
 	return &response, nil
 }
 

--- a/sealos-complik-admin/internal/modules/projectconfig/services.go
+++ b/sealos-complik-admin/internal/modules/projectconfig/services.go
@@ -8,6 +8,7 @@ import (
 
 	mysqlDriver "github.com/go-sql-driver/mysql"
 	"gorm.io/gorm"
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 var (
@@ -123,6 +124,25 @@ func (s *Service) ListProjectConfigs(ctx context.Context) ([]ProjectConfigRespon
 	}
 
 	return responses, nil
+}
+
+func (s *Service) ListProjectConfigsPage(
+	ctx context.Context,
+	options pagequery.Options,
+	keyword string,
+) (*PaginatedProjectConfigResponse, error) {
+	projectConfigs, total, err := s.repository.ListProjectConfigsPage(ctx, options, keyword)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]ProjectConfigResponse, 0, len(projectConfigs))
+	for i := range projectConfigs {
+		responses = append(responses, *toProjectConfigResponse(&projectConfigs[i]))
+	}
+
+	response := pagequery.NewPaginatedResponse(responses, total, options)
+	return &response, nil
 }
 
 // ListProjectConfigsByType returns project configurations filtered by config type.

--- a/sealos-complik-admin/internal/modules/unban/dto.go
+++ b/sealos-complik-admin/internal/modules/unban/dto.go
@@ -1,6 +1,10 @@
 package unban
 
-import "time"
+import (
+	"time"
+
+	"sealos-complik-admin/internal/modules/pagequery"
+)
 
 type UnbanNamespaceRequest struct {
 	Namespace string `uri:"namespace" binding:"required,max=255"`
@@ -8,6 +12,12 @@ type UnbanNamespaceRequest struct {
 
 type UnbanIDRequest struct {
 	ID uint64 `uri:"id" binding:"required,min=1"`
+}
+
+type ListUnbansQueryRequest struct {
+	Page         int    `form:"page"`
+	Keyword      string `form:"keyword"`
+	OperatorName string `form:"operator_name"`
 }
 
 type CreateUnbanRequest struct {
@@ -22,3 +32,5 @@ type UnbanResponse struct {
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 }
+
+type PaginatedUnbanResponse = pagequery.PaginatedResponse[UnbanResponse]

--- a/sealos-complik-admin/internal/modules/unban/handler.go
+++ b/sealos-complik-admin/internal/modules/unban/handler.go
@@ -99,6 +99,7 @@ func (h *Handler) ListUnbansPage(c *gin.Context) {
 			"message": "invalid request query",
 			"error":   err.Error(),
 		})
+
 		return
 	}
 
@@ -110,7 +111,12 @@ func (h *Handler) ListUnbansPage(c *gin.Context) {
 		return
 	}
 
-	resp, err := h.service.ListUnbansPage(c.Request.Context(), options, req.Keyword, req.OperatorName)
+	resp, err := h.service.ListUnbansPage(
+		c.Request.Context(),
+		options,
+		req.Keyword,
+		req.OperatorName,
+	)
 	if err != nil {
 		h.respondWithServiceError(c, err, "failed to list unbans")
 		return

--- a/sealos-complik-admin/internal/modules/unban/handler.go
+++ b/sealos-complik-admin/internal/modules/unban/handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 type Handler struct {
@@ -77,7 +78,39 @@ func (h *Handler) GetUnbans(c *gin.Context) {
 
 // ListUnbans handles listing all unban records.
 func (h *Handler) ListUnbans(c *gin.Context) {
+	if pagequery.HasPage(c.Query("page")) {
+		h.ListUnbansPage(c)
+		return
+	}
+
 	resp, err := h.service.ListUnbans(c.Request.Context())
+	if err != nil {
+		h.respondWithServiceError(c, err, "failed to list unbans")
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+func (h *Handler) ListUnbansPage(c *gin.Context) {
+	var req ListUnbansQueryRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid request query",
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	options, err := pagequery.NewOptions(req.Page)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid page query",
+		})
+		return
+	}
+
+	resp, err := h.service.ListUnbansPage(c.Request.Context(), options, req.Keyword, req.OperatorName)
 	if err != nil {
 		h.respondWithServiceError(c, err, "failed to list unbans")
 		return

--- a/sealos-complik-admin/internal/modules/unban/repository.go
+++ b/sealos-complik-admin/internal/modules/unban/repository.go
@@ -2,8 +2,10 @@ package unban
 
 import (
 	"context"
+	"strings"
 
 	"gorm.io/gorm"
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 type Repository struct {
@@ -48,6 +50,44 @@ func (r *Repository) ListUnbans(ctx context.Context) ([]Unban, error) {
 	}
 
 	return unbans, nil
+}
+
+func (r *Repository) ListUnbansPage(
+	ctx context.Context,
+	options pagequery.Options,
+	keyword string,
+	operatorName string,
+) ([]Unban, int64, error) {
+	var total int64
+	countQuery := r.buildListQuery(ctx, keyword, operatorName)
+	if err := countQuery.Model(&Unban{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var unbans []Unban
+	query := r.buildListQuery(ctx, keyword, operatorName)
+	if err := query.
+		Order("created_at DESC, id DESC").
+		Limit(options.PageSize).
+		Offset(options.Offset()).
+		Find(&unbans).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return unbans, total, nil
+}
+
+func (r *Repository) buildListQuery(ctx context.Context, keyword string, operatorName string) *gorm.DB {
+	query := r.db.WithContext(ctx).Model(&Unban{})
+	if strings.TrimSpace(keyword) != "" {
+		value := "%" + strings.ToLower(strings.TrimSpace(keyword)) + "%"
+		query = query.Where("LOWER(namespace) LIKE ?", value)
+	}
+	if strings.TrimSpace(operatorName) != "" {
+		query = query.Where("operator_name = ?", strings.TrimSpace(operatorName))
+	}
+
+	return query
 }
 
 // DeleteUnbanByID deletes a single unban record by id.

--- a/sealos-complik-admin/internal/modules/unban/repository.go
+++ b/sealos-complik-admin/internal/modules/unban/repository.go
@@ -59,12 +59,14 @@ func (r *Repository) ListUnbansPage(
 	operatorName string,
 ) ([]Unban, int64, error) {
 	var total int64
+
 	countQuery := r.buildListQuery(ctx, keyword, operatorName)
 	if err := countQuery.Model(&Unban{}).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 
 	var unbans []Unban
+
 	query := r.buildListQuery(ctx, keyword, operatorName)
 	if err := query.
 		Order("created_at DESC, id DESC").
@@ -77,12 +79,17 @@ func (r *Repository) ListUnbansPage(
 	return unbans, total, nil
 }
 
-func (r *Repository) buildListQuery(ctx context.Context, keyword string, operatorName string) *gorm.DB {
+func (r *Repository) buildListQuery(
+	ctx context.Context,
+	keyword string,
+	operatorName string,
+) *gorm.DB {
 	query := r.db.WithContext(ctx).Model(&Unban{})
 	if strings.TrimSpace(keyword) != "" {
 		value := "%" + strings.ToLower(strings.TrimSpace(keyword)) + "%"
 		query = query.Where("LOWER(namespace) LIKE ?", value)
 	}
+
 	if strings.TrimSpace(operatorName) != "" {
 		query = query.Where("operator_name = ?", strings.TrimSpace(operatorName))
 	}

--- a/sealos-complik-admin/internal/modules/unban/services.go
+++ b/sealos-complik-admin/internal/modules/unban/services.go
@@ -105,6 +105,7 @@ func (s *Service) ListUnbansPage(
 	}
 
 	response := pagequery.NewPaginatedResponse(responses, total, options)
+
 	return &response, nil
 }
 

--- a/sealos-complik-admin/internal/modules/unban/services.go
+++ b/sealos-complik-admin/internal/modules/unban/services.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"gorm.io/gorm"
+	"sealos-complik-admin/internal/modules/pagequery"
 )
 
 var (
@@ -85,6 +86,26 @@ func (s *Service) ListUnbans(ctx context.Context) ([]UnbanResponse, error) {
 	}
 
 	return responses, nil
+}
+
+func (s *Service) ListUnbansPage(
+	ctx context.Context,
+	options pagequery.Options,
+	keyword string,
+	operatorName string,
+) (*PaginatedUnbanResponse, error) {
+	unbans, total, err := s.repository.ListUnbansPage(ctx, options, keyword, operatorName)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]UnbanResponse, 0, len(unbans))
+	for i := range unbans {
+		responses = append(responses, *toUnbanResponse(&unbans[i]))
+	}
+
+	response := pagequery.NewPaginatedResponse(responses, total, options)
+	return &response, nil
 }
 
 type normalizedUnbanInput struct {

--- a/sealos-complik-admin/internal/modules/violationquery/query.go
+++ b/sealos-complik-admin/internal/modules/violationquery/query.go
@@ -1,0 +1,69 @@
+package violationquery
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"sealos-complik-admin/internal/modules/pagequery"
+)
+
+var ErrInvalidQuery = errors.New("invalid violation list query")
+
+type ListInput struct {
+	IncludeAll bool
+	Page       int
+	Keyword    string
+	TimeRange  string
+	Now        time.Time
+}
+
+type ListOptions struct {
+	IncludeAll bool
+	pagequery.Options
+	Keyword   string
+	TimeRange string
+	StartTime *time.Time
+}
+
+func NewListOptions(input ListInput) (ListOptions, error) {
+	pageOptions, err := pagequery.NewOptions(input.Page)
+	if err != nil {
+		return ListOptions{}, ErrInvalidQuery
+	}
+
+	now := input.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	timeRange := strings.TrimSpace(input.TimeRange)
+	if timeRange == "" {
+		timeRange = "7d"
+	}
+
+	var startTime *time.Time
+	switch timeRange {
+	case "24h":
+		value := now.Add(-24 * time.Hour)
+		startTime = &value
+	case "7d":
+		value := now.AddDate(0, 0, -7)
+		startTime = &value
+	case "30d":
+		value := now.AddDate(0, 0, -30)
+		startTime = &value
+	case "all":
+		startTime = nil
+	default:
+		return ListOptions{}, ErrInvalidQuery
+	}
+
+	return ListOptions{
+		IncludeAll: input.IncludeAll,
+		Options:    pageOptions,
+		Keyword:    strings.TrimSpace(input.Keyword),
+		TimeRange:  timeRange,
+		StartTime:  startTime,
+	}, nil
+}

--- a/sealos-complik-admin/internal/modules/violationquery/query_test.go
+++ b/sealos-complik-admin/internal/modules/violationquery/query_test.go
@@ -1,0 +1,87 @@
+package violationquery
+
+import (
+	"testing"
+	"time"
+
+	"sealos-complik-admin/internal/modules/pagequery"
+)
+
+func TestNewListOptionsUsesFixedPageSize(t *testing.T) {
+	options, err := NewListOptions(ListInput{
+		IncludeAll: true,
+		Page:       3,
+		Keyword:    " namespace-a ",
+		TimeRange:  "7d",
+		Now:        time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC),
+	})
+
+	if err != nil {
+		t.Fatalf("NewListOptions() error = %v", err)
+	}
+	if options.Page != 3 {
+		t.Fatalf("Page = %d, want 3", options.Page)
+	}
+	if options.PageSize != pagequery.FixedPageSize {
+		t.Fatalf("PageSize = %d, want %d", options.PageSize, pagequery.FixedPageSize)
+	}
+	if options.Offset() != 20 {
+		t.Fatalf("Offset() = %d, want 20", options.Offset())
+	}
+	if options.Keyword != "namespace-a" {
+		t.Fatalf("Keyword = %q, want namespace-a", options.Keyword)
+	}
+	if options.StartTime == nil {
+		t.Fatal("StartTime = nil, want value")
+	}
+	if !options.StartTime.Equal(time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("StartTime = %s, want 2026-05-27T12:00:00Z", options.StartTime.Format(time.RFC3339))
+	}
+}
+
+func TestNewListOptionsDefaultsPageAndTimeRange(t *testing.T) {
+	options, err := NewListOptions(ListInput{
+		Now: time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC),
+	})
+
+	if err != nil {
+		t.Fatalf("NewListOptions() error = %v", err)
+	}
+	if options.Page != 1 {
+		t.Fatalf("Page = %d, want 1", options.Page)
+	}
+	if options.StartTime == nil {
+		t.Fatal("StartTime = nil, want default 7d value")
+	}
+	if !options.StartTime.Equal(time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("StartTime = %s, want 2026-05-27T12:00:00Z", options.StartTime.Format(time.RFC3339))
+	}
+}
+
+func TestNewListOptionsAcceptsAllTime(t *testing.T) {
+	options, err := NewListOptions(ListInput{
+		TimeRange: "all",
+		Now:       time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC),
+	})
+
+	if err != nil {
+		t.Fatalf("NewListOptions() error = %v", err)
+	}
+	if options.StartTime != nil {
+		t.Fatalf("StartTime = %v, want nil", options.StartTime)
+	}
+}
+
+func TestNewListOptionsRejectsInvalidPage(t *testing.T) {
+	_, err := NewListOptions(ListInput{Page: -1})
+	if err == nil {
+		t.Fatal("NewListOptions() error = nil, want error")
+	}
+}
+
+func TestNewListOptionsRejectsInvalidTimeRange(t *testing.T) {
+	_, err := NewListOptions(ListInput{TimeRange: "90d"})
+	if err == nil {
+		t.Fatal("NewListOptions() error = nil, want error")
+	}
+}

--- a/sealos-complik-admin/internal/modules/violationquery/query_test.go
+++ b/sealos-complik-admin/internal/modules/violationquery/query_test.go
@@ -1,86 +1,100 @@
-package violationquery
+package violationquery_test
 
 import (
 	"testing"
 	"time"
 
 	"sealos-complik-admin/internal/modules/pagequery"
+	"sealos-complik-admin/internal/modules/violationquery"
 )
 
 func TestNewListOptionsUsesFixedPageSize(t *testing.T) {
-	options, err := NewListOptions(ListInput{
+	options, err := violationquery.NewListOptions(violationquery.ListInput{
 		IncludeAll: true,
 		Page:       3,
 		Keyword:    " namespace-a ",
 		TimeRange:  "7d",
-		Now:        time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC),
+		Now:        time.Date(2026, time.June, 3, 12, 0, 0, 0, time.UTC),
 	})
-
 	if err != nil {
 		t.Fatalf("NewListOptions() error = %v", err)
 	}
+
 	if options.Page != 3 {
 		t.Fatalf("Page = %d, want 3", options.Page)
 	}
+
 	if options.PageSize != pagequery.FixedPageSize {
 		t.Fatalf("PageSize = %d, want %d", options.PageSize, pagequery.FixedPageSize)
 	}
+
 	if options.Offset() != 20 {
 		t.Fatalf("Offset() = %d, want 20", options.Offset())
 	}
+
 	if options.Keyword != "namespace-a" {
 		t.Fatalf("Keyword = %q, want namespace-a", options.Keyword)
 	}
+
 	if options.StartTime == nil {
 		t.Fatal("StartTime = nil, want value")
 	}
-	if !options.StartTime.Equal(time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)) {
-		t.Fatalf("StartTime = %s, want 2026-05-27T12:00:00Z", options.StartTime.Format(time.RFC3339))
+
+	if !options.StartTime.Equal(time.Date(2026, time.May, 27, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf(
+			"StartTime = %s, want 2026-05-27T12:00:00Z",
+			options.StartTime.Format(time.RFC3339),
+		)
 	}
 }
 
 func TestNewListOptionsDefaultsPageAndTimeRange(t *testing.T) {
-	options, err := NewListOptions(ListInput{
-		Now: time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC),
+	options, err := violationquery.NewListOptions(violationquery.ListInput{
+		Now: time.Date(2026, time.June, 3, 12, 0, 0, 0, time.UTC),
 	})
-
 	if err != nil {
 		t.Fatalf("NewListOptions() error = %v", err)
 	}
+
 	if options.Page != 1 {
 		t.Fatalf("Page = %d, want 1", options.Page)
 	}
+
 	if options.StartTime == nil {
 		t.Fatal("StartTime = nil, want default 7d value")
 	}
-	if !options.StartTime.Equal(time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)) {
-		t.Fatalf("StartTime = %s, want 2026-05-27T12:00:00Z", options.StartTime.Format(time.RFC3339))
+
+	if !options.StartTime.Equal(time.Date(2026, time.May, 27, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf(
+			"StartTime = %s, want 2026-05-27T12:00:00Z",
+			options.StartTime.Format(time.RFC3339),
+		)
 	}
 }
 
 func TestNewListOptionsAcceptsAllTime(t *testing.T) {
-	options, err := NewListOptions(ListInput{
+	options, err := violationquery.NewListOptions(violationquery.ListInput{
 		TimeRange: "all",
-		Now:       time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC),
+		Now:       time.Date(2026, time.June, 3, 12, 0, 0, 0, time.UTC),
 	})
-
 	if err != nil {
 		t.Fatalf("NewListOptions() error = %v", err)
 	}
+
 	if options.StartTime != nil {
 		t.Fatalf("StartTime = %v, want nil", options.StartTime)
 	}
 }
 
 func TestNewListOptionsRejectsInvalidPage(t *testing.T) {
-	_, err := NewListOptions(ListInput{Page: -1})
+	_, err := violationquery.NewListOptions(violationquery.ListInput{Page: -1})
 	if err == nil {
 		t.Fatal("NewListOptions() error = nil, want error")
 	}
 }
 
 func TestNewListOptionsRejectsInvalidTimeRange(t *testing.T) {
-	_, err := NewListOptions(ListInput{TimeRange: "90d"})
+	_, err := violationquery.NewListOptions(violationquery.ListInput{TimeRange: "90d"})
 	if err == nil {
 		t.Fatal("NewListOptions() error = nil, want error")
 	}

--- a/sealos-complik-admin/web/src/App.tsx
+++ b/sealos-complik-admin/web/src/App.tsx
@@ -14,6 +14,7 @@ export default function App() {
       <Route element={<AppLayout />}>
         <Route index element={<Navigate replace to="/overview" />} />
         <Route path="/overview" element={<OverviewPage />} />
+        <Route path="/namespaces" element={<NamespaceDetailPage />} />
         <Route path="/namespaces/:namespace" element={<NamespaceDetailPage />} />
         <Route path="/violations" element={<ViolationsPage />} />
         <Route path="/configs" element={<ConfigsPage />} />

--- a/sealos-complik-admin/web/src/components/AppLayout.tsx
+++ b/sealos-complik-admin/web/src/components/AppLayout.tsx
@@ -12,7 +12,7 @@ import { cn } from "../lib/utils";
 
 const navItems = [
   { label: "总览", path: "/overview", icon: LayoutGrid },
-  { label: "命名空间详情", path: "/namespaces/prod-finance", icon: ShieldCheck },
+  { label: "命名空间详情", path: "/namespaces", icon: ShieldCheck },
   { label: "违规中心", path: "/violations", icon: AlertTriangle },
   { label: "项目配置", path: "/configs", icon: FileCog },
   { label: "承诺书管理", path: "/commitments", icon: FileText },

--- a/sealos-complik-admin/web/src/components/ui.tsx
+++ b/sealos-complik-admin/web/src/components/ui.tsx
@@ -35,16 +35,18 @@ export function PageHeader({
 export function Button({
   children,
   variant = "secondary",
+  disabled = false,
   onClick,
   type = "button",
 }: {
   children: ReactNode;
   variant?: "primary" | "secondary" | "ghost" | "danger";
+  disabled?: boolean;
   onClick?: () => void;
   type?: "button" | "submit";
 }) {
   return (
-    <button className={cn("btn", `btn-${variant}`)} onClick={onClick} type={type}>
+    <button className={cn("btn", `btn-${variant}`)} disabled={disabled} onClick={onClick} type={type}>
       {children}
     </button>
   );
@@ -112,6 +114,54 @@ export function EmptyState({
         {description}
       </p>
       {action ? <div className="button-row" style={{ justifyContent: "center", marginTop: 18 }}>{action}</div> : null}
+    </div>
+  );
+}
+
+export function PaginationControls({
+  page,
+  pageSize,
+  total,
+  totalPages,
+  onPageChange,
+}: {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}) {
+  const hasPreviousPage = totalPages > 0 && page > 1;
+  const hasNextPage = totalPages > 0 && page < totalPages;
+
+  return (
+    <div className="pagination-row">
+      <span className="muted-text">
+        共 {total} 条，每页 {pageSize} 条
+      </span>
+      <div className="button-row">
+        <Button
+          variant="secondary"
+          disabled={!hasPreviousPage}
+          onClick={() => {
+            if (hasPreviousPage) onPageChange(page - 1);
+          }}
+        >
+          上一页
+        </Button>
+        <span className="pagination-label">
+          第 {totalPages === 0 ? 0 : page} / {totalPages} 页
+        </span>
+        <Button
+          variant="secondary"
+          disabled={!hasNextPage}
+          onClick={() => {
+            if (hasNextPage) onPageChange(page + 1);
+          }}
+        >
+          下一页
+        </Button>
+      </div>
     </div>
   );
 }

--- a/sealos-complik-admin/web/src/contexts/AppDataContext.tsx
+++ b/sealos-complik-admin/web/src/contexts/AppDataContext.tsx
@@ -303,7 +303,6 @@ function buildStats(
 function buildLatestViolations(violations: ViolationRecord[]): ActivityItem[] {
   return [...violations]
     .sort((a, b) => getTimeMs(b.detectedAtMs, b.detectedAt) - getTimeMs(a.detectedAtMs, a.detectedAt))
-    .slice(0, 3)
     .map((item) => ({
       id: item.id,
       namespace: item.namespace,
@@ -358,7 +357,6 @@ function buildLatestActions(
 
   return actions
     .sort(compareNewestFirst)
-    .slice(0, 3)
     .map(({ sortTime: _sortTime, sequence: _sequence, ...item }) => item);
 }
 

--- a/sealos-complik-admin/web/src/lib/api.ts
+++ b/sealos-complik-admin/web/src/lib/api.ts
@@ -8,7 +8,11 @@ import type {
   CreateConfigInput,
   UpdateConfigInput,
   CreateUnbanInput,
+  PaginatedViolationRecords,
+  PaginatedRecords,
+  RecordListQuery,
   UnbanRecord,
+  ViolationListQuery,
   ViolationRecord,
 } from "../types";
 
@@ -89,6 +93,45 @@ type ProcscanViolationDto = {
   created_at?: string;
   updated_at?: string;
 };
+
+type PaginatedDto<T> = {
+  list: T[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+};
+
+function toPaginatedRecords<TDto, TRecord>(
+  data: PaginatedDto<TDto>,
+  mapper: (item: TDto) => TRecord,
+): PaginatedRecords<TRecord> {
+  return {
+    list: data.list.map(mapper),
+    total: data.total,
+    page: data.page,
+    pageSize: data.page_size,
+    totalPages: data.total_pages,
+  };
+}
+
+function buildRecordListParams(query: RecordListQuery) {
+  const params = new URLSearchParams({
+    page: String(query.page),
+  });
+
+  const keyword = query.keyword?.trim();
+  if (keyword) {
+    params.set("keyword", keyword);
+  }
+
+  const operatorName = query.operatorName?.trim();
+  if (operatorName) {
+    params.set("operator_name", operatorName);
+  }
+
+  return params;
+}
 
 async function request<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
   const headers = new Headers(init?.headers);
@@ -278,6 +321,11 @@ export async function listConfigRecords() {
   return data.map(toConfigRecord);
 }
 
+export async function listConfigRecordsPage(query: RecordListQuery): Promise<PaginatedRecords<ConfigRecord>> {
+  const data = await request<PaginatedDto<ProjectConfigDto>>(`/api/configs?${buildRecordListParams(query).toString()}`);
+  return toPaginatedRecords(data, toConfigRecord);
+}
+
 export async function createConfigRecord(input: CreateConfigInput) {
   await request("/api/configs", {
     method: "POST",
@@ -311,6 +359,11 @@ export async function updateConfigRecord(configName: string, input: UpdateConfig
 export async function listCommitmentRecords() {
   const data = await request<CommitmentDto[]>("/api/commitments");
   return data.map(toCommitmentRecord);
+}
+
+export async function listCommitmentRecordsPage(query: RecordListQuery): Promise<PaginatedRecords<CommitmentRecord>> {
+  const data = await request<PaginatedDto<CommitmentDto>>(`/api/commitments?${buildRecordListParams(query).toString()}`);
+  return toPaginatedRecords(data, toCommitmentRecord);
 }
 
 export async function createCommitmentRecord(input: CreateCommitmentInput) {
@@ -361,6 +414,11 @@ export function buildBanScreenshotPreviewURL(fileURL: string) {
 export async function listBanRecords() {
   const data = await request<BanDto[]>("/api/bans");
   return data.map(toBanRecord);
+}
+
+export async function listBanRecordsPage(query: RecordListQuery): Promise<PaginatedRecords<BanRecord>> {
+  const data = await request<PaginatedDto<BanDto>>(`/api/bans?${buildRecordListParams(query).toString()}`);
+  return toPaginatedRecords(data, toBanRecord);
 }
 
 export async function createBanRecord(input: CreateBanInput) {
@@ -426,6 +484,11 @@ export async function listUnbanRecords() {
   return data.map(toUnbanRecord);
 }
 
+export async function listUnbanRecordsPage(query: RecordListQuery): Promise<PaginatedRecords<UnbanRecord>> {
+  const data = await request<PaginatedDto<UnbanDto>>(`/api/unbans?${buildRecordListParams(query).toString()}`);
+  return toPaginatedRecords(data, toUnbanRecord);
+}
+
 export async function createUnbanRecord(input: CreateUnbanInput) {
   await request("/api/unbans", {
     method: "POST",
@@ -452,6 +515,27 @@ export async function listViolationRecords() {
     ...complikData.filter(isComplikIllegal).map(toComplikViolationRecord),
     ...procscanData.filter(isProcscanIllegal).map(toProcscanViolationRecord),
   ].sort((a, b) => toTimestamp(b.detectedAt) - toTimestamp(a.detectedAt));
+}
+
+export async function listViolationRecordsPage(query: ViolationListQuery): Promise<PaginatedViolationRecords> {
+  const params = new URLSearchParams({
+    include_all: String(query.scope === "all"),
+    page: String(query.page),
+    time_range: query.timeRange,
+  });
+
+  const keyword = query.keyword.trim();
+  if (keyword) {
+    params.set("keyword", keyword);
+  }
+
+  if (query.type === "complik") {
+    const data = await request<PaginatedDto<ComplikViolationDto>>(`/api/complik-violations?${params.toString()}`);
+    return toPaginatedRecords(data, toComplikViolationRecord);
+  }
+
+  const data = await request<PaginatedDto<ProcscanViolationDto>>(`/api/procscan-violations?${params.toString()}`);
+  return toPaginatedRecords(data, toProcscanViolationRecord);
 }
 
 export async function deleteViolationRecord(id: number, type: ViolationRecord["type"]) {

--- a/sealos-complik-admin/web/src/lib/utils.ts
+++ b/sealos-complik-admin/web/src/lib/utils.ts
@@ -88,3 +88,25 @@ export function summarizeMarkdown(value: string, maxLength = 80) {
 
   return `${collapsed.slice(0, maxLength).trim()}...`;
 }
+
+export const FIXED_PAGE_SIZE = 10;
+
+export function clampPage(page: number, totalPages: number) {
+  if (totalPages <= 0) return 1;
+  return Math.min(Math.max(page, 1), totalPages);
+}
+
+export function paginateItems<T>(items: T[], page: number, pageSize = FIXED_PAGE_SIZE) {
+  const total = items.length;
+  const totalPages = Math.ceil(total / pageSize);
+  const safePage = clampPage(page, totalPages);
+  const start = (safePage - 1) * pageSize;
+
+  return {
+    list: items.slice(start, start + pageSize),
+    total,
+    page: safePage,
+    pageSize,
+    totalPages,
+  };
+}

--- a/sealos-complik-admin/web/src/pages/BansPage.tsx
+++ b/sealos-complik-admin/web/src/pages/BansPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   Button,
@@ -10,15 +10,16 @@ import {
   Input,
   Modal,
   PageHeader,
+  PaginationControls,
   Select,
   SurfaceCard,
 } from "../components/ui";
 import { MarkdownRenderer } from "../components/MarkdownRenderer";
 import { useAppData } from "../contexts/AppDataContext";
 import { useManagedOperatorOptions } from "../hooks/useOperatorOptions";
-import { buildBanScreenshotPreviewURL } from "../lib/api";
+import { buildBanScreenshotPreviewURL, listBanRecordsPage } from "../lib/api";
 import { summarizeMarkdown } from "../lib/utils";
-import type { BanRecord } from "../types";
+import type { BanRecord, PaginatedRecords } from "../types";
 
 export function BansPage() {
   const navigate = useNavigate();
@@ -28,6 +29,16 @@ export function BansPage() {
   const [open, setOpen] = useState(false);
   const [keyword, setKeyword] = useState(() => searchParams.get("namespace") ?? "");
   const [operatorFilter, setOperatorFilter] = useState("");
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState<PaginatedRecords<BanRecord>>({
+    list: [],
+    total: 0,
+    page: 1,
+    pageSize: 10,
+    totalPages: 0,
+  });
+  const [listError, setListError] = useState<string | null>(null);
+  const [isListLoading, setIsListLoading] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<BanRecord | null>(null);
   const [namespace, setNamespace] = useState("");
   const [reason, setReason] = useState("");
@@ -68,7 +79,40 @@ export function BansPage() {
 
   useEffect(() => {
     setKeyword(searchParams.get("namespace") ?? "");
+    setPage(1);
   }, [searchParams]);
+
+  const loadRows = useCallback(async () => {
+    setIsListLoading(true);
+    setListError(null);
+    try {
+      const nextData = await listBanRecordsPage({
+        page,
+        keyword,
+        operatorName: operatorFilter,
+      });
+      if (nextData.totalPages > 0 && page > nextData.totalPages) {
+        setPage(nextData.totalPages);
+        return;
+      }
+      setData(nextData);
+    } catch (err) {
+      setListError(err instanceof Error ? err.message : "封禁记录加载失败");
+      setData({
+        list: [],
+        total: 0,
+        page,
+        pageSize: 10,
+        totalPages: 0,
+      });
+    } finally {
+      setIsListLoading(false);
+    }
+  }, [keyword, operatorFilter, page]);
+
+  useEffect(() => {
+    void loadRows();
+  }, [loadRows]);
 
   const appendScreenshots = (files: File[]) => {
     if (files.length === 0) {
@@ -108,17 +152,7 @@ export function BansPage() {
     setFormError(null);
   };
 
-  const rows = useMemo(() => {
-    return banRecords.filter((item) => {
-      if (keyword && !item.namespace.toLowerCase().includes(keyword.toLowerCase())) {
-        return false;
-      }
-      if (operatorFilter && item.operatorName !== operatorFilter) {
-        return false;
-      }
-      return true;
-    });
-  }, [banRecords, keyword, operatorFilter]);
+  const rows = data.list;
 
   const handleCreateBan = async () => {
     if (submitting) {
@@ -140,6 +174,7 @@ export function BansPage() {
       });
       setOpen(false);
       resetForm();
+      await loadRows();
     } catch (err) {
       setFormError(err instanceof Error ? err.message : "新增封禁记录失败");
     } finally {
@@ -159,10 +194,23 @@ export function BansPage() {
       <SurfaceCard>
         <div className="toolbar">
           <Field label="namespace">
-            <Input placeholder="按 namespace 搜索" value={keyword} onChange={(event) => setKeyword(event.target.value)} />
+            <Input
+              placeholder="按 namespace 搜索"
+              value={keyword}
+              onChange={(event) => {
+                setKeyword(event.target.value);
+                setPage(1);
+              }}
+            />
           </Field>
           <Field label="操作人">
-            <Select value={operatorFilter} onChange={(event) => setOperatorFilter(event.target.value)}>
+            <Select
+              value={operatorFilter}
+              onChange={(event) => {
+                setOperatorFilter(event.target.value);
+                setPage(1);
+              }}
+            >
               <option value="">全部操作人</option>
               {operatorOptions.map((option) => (
                 <option key={option} value={option}>
@@ -175,7 +223,19 @@ export function BansPage() {
       </SurfaceCard>
 
       <SurfaceCard className="data-table-wrap" padded={false}>
-        {rows.length > 0 ? (
+        {listError ? (
+          <div style={{ padding: 20 }}>
+            <EmptyState
+              title="封禁记录加载失败"
+              description={listError}
+              action={<Button variant="secondary" onClick={() => void loadRows()}>重新加载</Button>}
+            />
+          </div>
+        ) : isListLoading ? (
+          <div style={{ padding: 20 }}>
+            <EmptyState title="封禁记录加载中" description="正在同步当前页数据。" />
+          </div>
+        ) : rows.length > 0 ? (
           <table className="data-table">
             <thead>
               <tr>
@@ -220,6 +280,14 @@ export function BansPage() {
           </div>
         )}
       </SurfaceCard>
+
+      <PaginationControls
+        page={page}
+        pageSize={data.pageSize}
+        total={data.total}
+        totalPages={data.totalPages}
+        onPageChange={setPage}
+      />
 
       <Drawer
         description="这里展示描述内容和截图附件。"
@@ -416,6 +484,7 @@ export function BansPage() {
               setSelected(null);
             }
             setPendingDelete(null);
+            void loadRows();
           });
         }}
         open={Boolean(pendingDelete)}

--- a/sealos-complik-admin/web/src/pages/CommitmentsPage.tsx
+++ b/sealos-complik-admin/web/src/pages/CommitmentsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Button,
@@ -10,27 +10,67 @@ import {
   Input,
   Modal,
   PageHeader,
+  PaginationControls,
   SurfaceCard,
 } from "../components/ui";
 import { useAppData } from "../contexts/AppDataContext";
-import { buildCommitmentDownloadURL } from "../lib/api";
-import type { CommitmentRecord } from "../types";
+import { buildCommitmentDownloadURL, listCommitmentRecordsPage } from "../lib/api";
+import type { CommitmentRecord, PaginatedRecords } from "../types";
 
 export function CommitmentsPage() {
   const navigate = useNavigate();
-  const { commitmentRecords, createCommitmentRecord, deleteCommitmentRecord } = useAppData();
+  const { createCommitmentRecord, deleteCommitmentRecord } = useAppData();
   const [selected, setSelected] = useState<CommitmentRecord | null>(null);
   const [open, setOpen] = useState(false);
   const [keyword, setKeyword] = useState("");
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState<PaginatedRecords<CommitmentRecord>>({
+    list: [],
+    total: 0,
+    page: 1,
+    pageSize: 10,
+    totalPages: 0,
+  });
+  const [listError, setListError] = useState<string | null>(null);
+  const [isListLoading, setIsListLoading] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<CommitmentRecord | null>(null);
   const [namespace, setNamespace] = useState("");
   const [file, setFile] = useState<File | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
-  const rows = useMemo(() => {
-    return commitmentRecords.filter((item) => item.namespace.toLowerCase().includes(keyword.toLowerCase()));
-  }, [commitmentRecords, keyword]);
+  const loadRows = useCallback(async () => {
+    setIsListLoading(true);
+    setListError(null);
+    try {
+      const nextData = await listCommitmentRecordsPage({
+        page,
+        keyword,
+      });
+      if (nextData.totalPages > 0 && page > nextData.totalPages) {
+        setPage(nextData.totalPages);
+        return;
+      }
+      setData(nextData);
+    } catch (err) {
+      setListError(err instanceof Error ? err.message : "承诺书记录加载失败");
+      setData({
+        list: [],
+        total: 0,
+        page,
+        pageSize: 10,
+        totalPages: 0,
+      });
+    } finally {
+      setIsListLoading(false);
+    }
+  }, [keyword, page]);
+
+  useEffect(() => {
+    void loadRows();
+  }, [loadRows]);
+
+  const rows = data.list;
 
   const handleCreateCommitment = async () => {
     if (!namespace.trim() || !file) {
@@ -52,6 +92,7 @@ export function CommitmentsPage() {
       setOpen(false);
       setNamespace("");
       setFile(null);
+      await loadRows();
     } catch (err) {
       setFormError(err instanceof Error ? err.message : "上传承诺书失败");
     } finally {
@@ -71,13 +112,32 @@ export function CommitmentsPage() {
       <SurfaceCard>
         <div className="toolbar">
           <Field label="namespace 搜索">
-            <Input placeholder="输入 namespace" value={keyword} onChange={(event) => setKeyword(event.target.value)} />
+            <Input
+              placeholder="输入 namespace"
+              value={keyword}
+              onChange={(event) => {
+                setKeyword(event.target.value);
+                setPage(1);
+              }}
+            />
           </Field>
         </div>
       </SurfaceCard>
 
       <SurfaceCard className="data-table-wrap" padded={false}>
-        {rows.length > 0 ? (
+        {listError ? (
+          <div style={{ padding: 20 }}>
+            <EmptyState
+              title="承诺书记录加载失败"
+              description={listError}
+              action={<Button variant="secondary" onClick={() => void loadRows()}>重新加载</Button>}
+            />
+          </div>
+        ) : isListLoading ? (
+          <div style={{ padding: 20 }}>
+            <EmptyState title="承诺书记录加载中" description="正在同步当前页数据。" />
+          </div>
+        ) : rows.length > 0 ? (
           <table className="data-table">
             <thead>
               <tr>
@@ -126,6 +186,14 @@ export function CommitmentsPage() {
           </div>
         )}
       </SurfaceCard>
+
+      <PaginationControls
+        page={page}
+        pageSize={data.pageSize}
+        total={data.total}
+        totalPages={data.totalPages}
+        onPageChange={setPage}
+      />
 
       <Drawer
         description="这里展示承诺书记录详情，并提供跳转到 namespace 详情的入口。"
@@ -219,6 +287,7 @@ export function CommitmentsPage() {
               setSelected(null);
             }
             setPendingDelete(null);
+            void loadRows();
           });
         }}
         open={Boolean(pendingDelete)}

--- a/sealos-complik-admin/web/src/pages/ConfigsPage.tsx
+++ b/sealos-complik-admin/web/src/pages/ConfigsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Button,
   ConfirmModal,
@@ -9,11 +9,13 @@ import {
   Input,
   Modal,
   PageHeader,
+  PaginationControls,
   SurfaceCard,
   TextArea,
 } from "../components/ui";
 import { useAppData } from "../contexts/AppDataContext";
-import type { ConfigRecord, CreateConfigInput } from "../types";
+import { listConfigRecordsPage } from "../lib/api";
+import type { ConfigRecord, CreateConfigInput, PaginatedRecords } from "../types";
 
 type ImportConfigRecord = {
   config_name?: unknown;
@@ -85,12 +87,22 @@ function parseImportedConfigs(source: string): CreateConfigInput[] {
 }
 
 export function ConfigsPage() {
-  const { configRecords, createConfigRecord, updateConfigRecord, deleteConfigRecord } = useAppData();
+  const { createConfigRecord, updateConfigRecord, deleteConfigRecord } = useAppData();
   const [selected, setSelected] = useState<ConfigRecord | null>(null);
   const [open, setOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [nameKeyword, setNameKeyword] = useState("");
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState<PaginatedRecords<ConfigRecord>>({
+    list: [],
+    total: 0,
+    page: 1,
+    pageSize: 10,
+    totalPages: 0,
+  });
+  const [listError, setListError] = useState<string | null>(null);
+  const [isListLoading, setIsListLoading] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<ConfigRecord | null>(null);
   const [configName, setConfigName] = useState("");
   const [configType, setConfigType] = useState("");
@@ -108,14 +120,38 @@ export function ConfigsPage() {
   const [importSubmitting, setImportSubmitting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
 
-  const rows = useMemo(() => {
-    return configRecords.filter((item) => {
-      if (nameKeyword && !item.configName.toLowerCase().includes(nameKeyword.toLowerCase())) {
-        return false;
+  const loadRows = useCallback(async () => {
+    setIsListLoading(true);
+    setListError(null);
+    try {
+      const nextData = await listConfigRecordsPage({
+        page,
+        keyword: nameKeyword,
+      });
+      if (nextData.totalPages > 0 && page > nextData.totalPages) {
+        setPage(nextData.totalPages);
+        return;
       }
-      return true;
-    });
-  }, [configRecords, nameKeyword]);
+      setData(nextData);
+    } catch (err) {
+      setListError(err instanceof Error ? err.message : "项目配置加载失败");
+      setData({
+        list: [],
+        total: 0,
+        page,
+        pageSize: 10,
+        totalPages: 0,
+      });
+    } finally {
+      setIsListLoading(false);
+    }
+  }, [nameKeyword, page]);
+
+  useEffect(() => {
+    void loadRows();
+  }, [loadRows]);
+
+  const rows = data.list;
 
   const handleCreateConfig = async () => {
     if (!configName.trim() || !configType.trim() || !value.trim()) {
@@ -144,6 +180,7 @@ export function ConfigsPage() {
       setConfigType("");
       setDescription("");
       setValue('{\n  "enabled": true,\n  "threshold": 3\n}');
+      await loadRows();
     } catch (err) {
       setFormError(err instanceof Error ? err.message : "新增配置失败");
     } finally {
@@ -201,6 +238,7 @@ export function ConfigsPage() {
       }
       setImportOpen(false);
       setImportValue("");
+      await loadRows();
     } catch (err) {
       setImportError(err instanceof Error ? err.message : "导入配置失败");
     } finally {
@@ -253,6 +291,7 @@ export function ConfigsPage() {
           : prev,
       );
       setEditOpen(false);
+      await loadRows();
     } catch (err) {
       setEditError(err instanceof Error ? err.message : "修改配置失败");
     } finally {
@@ -295,13 +334,32 @@ export function ConfigsPage() {
       <SurfaceCard>
         <div className="toolbar">
           <Field label="配置名搜索">
-            <Input placeholder="按 config_name 搜索" value={nameKeyword} onChange={(event) => setNameKeyword(event.target.value)} />
+            <Input
+              placeholder="按 config_name 搜索"
+              value={nameKeyword}
+              onChange={(event) => {
+                setNameKeyword(event.target.value);
+                setPage(1);
+              }}
+            />
           </Field>
         </div>
       </SurfaceCard>
 
       <SurfaceCard className="data-table-wrap" padded={false}>
-        {rows.length > 0 ? (
+        {listError ? (
+          <div style={{ padding: 20 }}>
+            <EmptyState
+              title="项目配置加载失败"
+              description={listError}
+              action={<Button variant="secondary" onClick={() => void loadRows()}>重新加载</Button>}
+            />
+          </div>
+        ) : isListLoading ? (
+          <div style={{ padding: 20 }}>
+            <EmptyState title="项目配置加载中" description="正在同步当前页数据。" />
+          </div>
+        ) : rows.length > 0 ? (
           <table className="data-table">
             <thead>
               <tr>
@@ -340,6 +398,14 @@ export function ConfigsPage() {
           </div>
         )}
       </SurfaceCard>
+
+      <PaginationControls
+        page={page}
+        pageSize={data.pageSize}
+        total={data.total}
+        totalPages={data.totalPages}
+        onPageChange={setPage}
+      />
 
       <Drawer
         description="右侧抽屉展示配置详情，并保留足够宽度展示 JSON 内容。"
@@ -523,6 +589,7 @@ export function ConfigsPage() {
               setSelected(null);
             }
             setPendingDelete(null);
+            void loadRows();
           });
         }}
         open={Boolean(pendingDelete)}

--- a/sealos-complik-admin/web/src/pages/NamespaceDetailPage.tsx
+++ b/sealos-complik-admin/web/src/pages/NamespaceDetailPage.tsx
@@ -1,5 +1,5 @@
 import { ArrowRight, Search } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createSearchParams, useNavigate, useParams } from "react-router-dom";
 import {
   Button,
@@ -9,13 +9,14 @@ import {
   EmptyState,
   Input,
   PageHeader,
+  PaginationControls,
   StatusPill,
   SurfaceCard,
 } from "../components/ui";
 import { MarkdownRenderer } from "../components/MarkdownRenderer";
 import { useAppData } from "../contexts/AppDataContext";
 import { buildCommitmentDownloadURL } from "../lib/api";
-import { formatURLWithDeviceProfile, formatViolationTypeLabel, summarizeMarkdown } from "../lib/utils";
+import { formatURLWithDeviceProfile, formatViolationTypeLabel, paginateItems, summarizeMarkdown } from "../lib/utils";
 import type { ViolationRecord } from "../types";
 
 function toneByBoolean(value: boolean, positiveTone: "success" | "warn" | "danger" = "success") {
@@ -27,25 +28,36 @@ export function NamespaceDetailPage() {
   const navigate = useNavigate();
   const { deleteViolationRecord, error, isLoading, namespaceProfiles, refreshAll, violations } = useAppData();
   const [keyword, setKeyword] = useState("");
+  const [violationPage, setViolationPage] = useState(1);
+  const [timelinePage, setTimelinePage] = useState(1);
   const [selectedViolation, setSelectedViolation] = useState<ViolationRecord | null>(null);
   const [pendingDelete, setPendingDelete] = useState<ViolationRecord | null>(null);
 
   const profile = useMemo(
-    () => namespaceProfiles.find((item) => item.namespace === namespace) ?? namespaceProfiles[0] ?? null,
+    () => (namespace ? namespaceProfiles.find((item) => item.namespace === namespace) ?? null : null),
     [namespace, namespaceProfiles],
   );
   const recentViolations = useMemo(
-    () => (profile ? violations.filter((item) => item.namespace === profile.namespace).slice(0, 5) : []),
+    () => (profile ? violations.filter((item) => item.namespace === profile.namespace) : []),
     [profile, violations],
   );
+  const paginatedViolations = useMemo(() => paginateItems(recentViolations, violationPage), [recentViolations, violationPage]);
+  const paginatedTimeline = useMemo(() => paginateItems(profile?.timeline ?? [], timelinePage), [profile?.timeline, timelinePage]);
+
+  useEffect(() => {
+    setViolationPage(1);
+    setTimelinePage(1);
+  }, [profile?.namespace]);
 
   if (!profile) {
+    const canNavigate = keyword.trim().length > 0;
+
     return (
       <div className="page-container">
         <PageHeader
           kicker="Namespace"
           title={namespace ?? "命名空间详情"}
-          description="先判断违规记录、封禁和承诺书情况，再回看最近违规和处置时间线。"
+          description="输入 namespace 后查看违规记录、封禁、承诺书和处置时间线。"
           actions={
             <Button
               variant="secondary"
@@ -59,9 +71,27 @@ export function NamespaceDetailPage() {
         />
         <SurfaceCard>
           <EmptyState
-            title={isLoading ? "命名空间数据加载中" : "未找到命名空间数据"}
-            description={error ?? "当前没有可展示的命名空间记录，请先检查后端数据是否已同步。"}
+            title={isLoading ? "命名空间数据加载中" : namespace ? "未找到命名空间数据" : "请选择命名空间"}
+            description={error ?? (namespace ? "当前 namespace 没有可展示记录，请检查数据是否已同步。" : "直接点击命名空间详情时先停留在查询入口。")}
           />
+          <div className="toolbar" style={{ marginTop: 20 }}>
+            <label className="field">
+              <span className="field-label">namespace</span>
+              <div style={{ display: "flex", gap: 12 }}>
+                <Input value={keyword} onChange={(event) => setKeyword(event.target.value)} placeholder="输入 namespace" />
+                <Button
+                  disabled={!canNavigate}
+                  variant="secondary"
+                  onClick={() => {
+                    if (!canNavigate) return;
+                    navigate(`/namespaces/${keyword.trim()}`);
+                  }}
+                >
+                  <Search size={16} /> 查看详情
+                </Button>
+              </div>
+            </label>
+          </div>
         </SurfaceCard>
       </div>
     );
@@ -200,7 +230,7 @@ export function NamespaceDetailPage() {
               <p className="panel-description">点击某条记录会在右侧展开详情抽屉。</p>
             </div>
           </div>
-          {recentViolations.length > 0 ? (
+          {paginatedViolations.list.length > 0 ? (
             <div className="data-table-wrap">
               <table className="data-table">
                 <thead>
@@ -212,7 +242,7 @@ export function NamespaceDetailPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {recentViolations.map((item) => (
+                  {paginatedViolations.list.map((item) => (
                     <tr key={item.id}>
                       <td>{formatViolationTypeLabel(item.type)}</td>
                       <td>
@@ -238,6 +268,13 @@ export function NamespaceDetailPage() {
               description="这个 namespace 目前没有需要跟进的违规事件。"
             />
           )}
+          <PaginationControls
+            page={paginatedViolations.page}
+            pageSize={paginatedViolations.pageSize}
+            total={paginatedViolations.total}
+            totalPages={paginatedViolations.totalPages}
+            onPageChange={setViolationPage}
+          />
         </SurfaceCard>
 
         <SurfaceCard>
@@ -248,7 +285,7 @@ export function NamespaceDetailPage() {
             </div>
           </div>
           <div className="timeline">
-            {profile.timeline.map((item) => (
+            {paginatedTimeline.list.map((item) => (
               <div className="timeline-item" key={item.id}>
                 <span className={`timeline-dot tone-${item.tone}`} style={{ backgroundColor: "currentColor" }} />
                 <div className="timeline-content">
@@ -261,6 +298,13 @@ export function NamespaceDetailPage() {
               </div>
             ))}
           </div>
+          <PaginationControls
+            page={paginatedTimeline.page}
+            pageSize={paginatedTimeline.pageSize}
+            total={paginatedTimeline.total}
+            totalPages={paginatedTimeline.totalPages}
+            onPageChange={setTimelinePage}
+          />
         </SurfaceCard>
       </div>
 

--- a/sealos-complik-admin/web/src/pages/OverviewPage.tsx
+++ b/sealos-complik-admin/web/src/pages/OverviewPage.tsx
@@ -1,11 +1,17 @@
 import { ArrowRight, RefreshCw } from "lucide-react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAppData } from "../contexts/AppDataContext";
-import { Button, PageHeader, StatusPill, SurfaceCard } from "../components/ui";
+import { Button, PageHeader, PaginationControls, StatusPill, SurfaceCard } from "../components/ui";
+import { paginateItems } from "../lib/utils";
 
 export function OverviewPage() {
   const navigate = useNavigate();
   const { latestActions, latestViolations, quickLinks, refreshAll, stats } = useAppData();
+  const [violationPage, setViolationPage] = useState(1);
+  const [actionPage, setActionPage] = useState(1);
+  const paginatedViolations = useMemo(() => paginateItems(latestViolations, violationPage), [latestViolations, violationPage]);
+  const paginatedActions = useMemo(() => paginateItems(latestActions, actionPage), [latestActions, actionPage]);
 
   return (
     <div className="page-container">
@@ -57,7 +63,7 @@ export function OverviewPage() {
             </Button>
           </div>
           <div className="activity-list">
-            {latestViolations.map((item) => (
+            {paginatedViolations.list.map((item) => (
               <div className="activity-item" key={item.id}>
                 <div className="activity-primary">
                   <button
@@ -77,6 +83,13 @@ export function OverviewPage() {
               </div>
             ))}
           </div>
+          <PaginationControls
+            page={paginatedViolations.page}
+            pageSize={paginatedViolations.pageSize}
+            total={paginatedViolations.total}
+            totalPages={paginatedViolations.totalPages}
+            onPageChange={setViolationPage}
+          />
         </SurfaceCard>
 
         <SurfaceCard>
@@ -87,7 +100,7 @@ export function OverviewPage() {
             </div>
           </div>
           <div className="activity-list">
-            {latestActions.map((item) => (
+            {paginatedActions.list.map((item) => (
               <div className="activity-item" key={item.id}>
                 <div className="activity-primary">
                   <button
@@ -109,6 +122,13 @@ export function OverviewPage() {
               </div>
             ))}
           </div>
+          <PaginationControls
+            page={paginatedActions.page}
+            pageSize={paginatedActions.pageSize}
+            total={paginatedActions.total}
+            totalPages={paginatedActions.totalPages}
+            onPageChange={setActionPage}
+          />
         </SurfaceCard>
       </section>
 

--- a/sealos-complik-admin/web/src/pages/UnbansPage.tsx
+++ b/sealos-complik-admin/web/src/pages/UnbansPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   Button,
@@ -10,12 +10,14 @@ import {
   Input,
   Modal,
   PageHeader,
+  PaginationControls,
   Select,
   SurfaceCard,
 } from "../components/ui";
 import { useAppData } from "../contexts/AppDataContext";
 import { useManagedOperatorOptions } from "../hooks/useOperatorOptions";
-import type { UnbanRecord } from "../types";
+import { listUnbanRecordsPage } from "../lib/api";
+import type { PaginatedRecords, UnbanRecord } from "../types";
 
 export function UnbansPage() {
   const navigate = useNavigate();
@@ -25,6 +27,16 @@ export function UnbansPage() {
   const [open, setOpen] = useState(false);
   const [keyword, setKeyword] = useState(() => searchParams.get("namespace") ?? "");
   const [operatorFilter, setOperatorFilter] = useState("");
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState<PaginatedRecords<UnbanRecord>>({
+    list: [],
+    total: 0,
+    page: 1,
+    pageSize: 10,
+    totalPages: 0,
+  });
+  const [listError, setListError] = useState<string | null>(null);
+  const [isListLoading, setIsListLoading] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<UnbanRecord | null>(null);
   const [namespace, setNamespace] = useState("");
   const [operatorName, setOperatorName] = useState("");
@@ -38,19 +50,42 @@ export function UnbansPage() {
 
   useEffect(() => {
     setKeyword(searchParams.get("namespace") ?? "");
+    setPage(1);
   }, [searchParams]);
 
-  const rows = useMemo(() => {
-    return unbanRecords.filter((item) => {
-      if (!item.namespace.toLowerCase().includes(keyword.toLowerCase())) {
-        return false;
+  const loadRows = useCallback(async () => {
+    setIsListLoading(true);
+    setListError(null);
+    try {
+      const nextData = await listUnbanRecordsPage({
+        page,
+        keyword,
+        operatorName: operatorFilter,
+      });
+      if (nextData.totalPages > 0 && page > nextData.totalPages) {
+        setPage(nextData.totalPages);
+        return;
       }
-      if (operatorFilter && item.operatorName !== operatorFilter) {
-        return false;
-      }
-      return true;
-    });
-  }, [keyword, operatorFilter, unbanRecords]);
+      setData(nextData);
+    } catch (err) {
+      setListError(err instanceof Error ? err.message : "解封记录加载失败");
+      setData({
+        list: [],
+        total: 0,
+        page,
+        pageSize: 10,
+        totalPages: 0,
+      });
+    } finally {
+      setIsListLoading(false);
+    }
+  }, [keyword, operatorFilter, page]);
+
+  useEffect(() => {
+    void loadRows();
+  }, [loadRows]);
+
+  const rows = data.list;
 
   const handleCreateUnban = async () => {
     if (!namespace.trim() || !operatorName.trim()) {
@@ -68,6 +103,7 @@ export function UnbansPage() {
       setOpen(false);
       setNamespace("");
       setOperatorName("");
+      await loadRows();
     } catch (err) {
       setFormError(err instanceof Error ? err.message : "新增解封记录失败");
     } finally {
@@ -87,10 +123,23 @@ export function UnbansPage() {
       <SurfaceCard>
         <div className="toolbar">
           <Field label="namespace">
-            <Input placeholder="按 namespace 搜索" value={keyword} onChange={(event) => setKeyword(event.target.value)} />
+            <Input
+              placeholder="按 namespace 搜索"
+              value={keyword}
+              onChange={(event) => {
+                setKeyword(event.target.value);
+                setPage(1);
+              }}
+            />
           </Field>
           <Field label="操作人">
-            <Select value={operatorFilter} onChange={(event) => setOperatorFilter(event.target.value)}>
+            <Select
+              value={operatorFilter}
+              onChange={(event) => {
+                setOperatorFilter(event.target.value);
+                setPage(1);
+              }}
+            >
               <option value="">全部操作人</option>
               {operatorOptions.map((option) => (
                 <option key={option} value={option}>
@@ -110,7 +159,19 @@ export function UnbansPage() {
       </SurfaceCard>
 
       <SurfaceCard className="data-table-wrap" padded={false}>
-        {rows.length > 0 ? (
+        {listError ? (
+          <div style={{ padding: 20 }}>
+            <EmptyState
+              title="解封记录加载失败"
+              description={listError}
+              action={<Button variant="secondary" onClick={() => void loadRows()}>重新加载</Button>}
+            />
+          </div>
+        ) : isListLoading ? (
+          <div style={{ padding: 20 }}>
+            <EmptyState title="解封记录加载中" description="正在同步当前页数据。" />
+          </div>
+        ) : rows.length > 0 ? (
           <table className="data-table">
             <thead>
               <tr>
@@ -153,6 +214,14 @@ export function UnbansPage() {
           </div>
         )}
       </SurfaceCard>
+
+      <PaginationControls
+        page={page}
+        pageSize={data.pageSize}
+        total={data.total}
+        totalPages={data.totalPages}
+        onPageChange={setPage}
+      />
 
       <Drawer
         description="解封记录详情保持轻量，只展示当前接口已有字段。"
@@ -237,6 +306,7 @@ export function UnbansPage() {
               setSelected(null);
             }
             setPendingDelete(null);
+            void loadRows();
           });
         }}
         open={Boolean(pendingDelete)}

--- a/sealos-complik-admin/web/src/pages/ViolationsPage.tsx
+++ b/sealos-complik-admin/web/src/pages/ViolationsPage.tsx
@@ -1,5 +1,6 @@
-import { RefreshCw } from "lucide-react";
-import { useMemo, useState } from "react";
+import { RefreshCw, Search } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import type { FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Button,
@@ -10,43 +11,93 @@ import {
   Field,
   Input,
   PageHeader,
+  PaginationControls,
   Select,
   SurfaceCard,
 } from "../components/ui";
 import { MarkdownRenderer } from "../components/MarkdownRenderer";
-import { useAppData } from "../contexts/AppDataContext";
+import { deleteViolationRecord as apiDeleteViolationRecord, listViolationRecordsPage } from "../lib/api";
 import { formatURLWithDeviceProfile, formatViolationTypeLabel } from "../lib/utils";
-import type { ViolationRecord, ViolationType } from "../types";
+import type { PaginatedViolationRecords, ViolationRecord, ViolationScope, ViolationTimeRange, ViolationType } from "../types";
 
 export function ViolationsPage() {
   const navigate = useNavigate();
-  const { deleteViolationRecord, error, isLoading, refreshAll, violations } = useAppData();
   const [tab, setTab] = useState<ViolationType>("complik");
+  const [scope, setScope] = useState<ViolationScope>("violations");
+  const [timeRange, setTimeRange] = useState<ViolationTimeRange>("7d");
+  const [page, setPage] = useState(1);
+  const [keywordInput, setKeywordInput] = useState("");
+  const [keyword, setKeyword] = useState("");
+  const [data, setData] = useState<PaginatedViolationRecords>({
+    list: [],
+    total: 0,
+    page: 1,
+    pageSize: 10,
+    totalPages: 0,
+  });
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
   const [selected, setSelected] = useState<ViolationRecord | null>(null);
-  const [namespaceKeyword, setNamespaceKeyword] = useState("");
   const [pendingDelete, setPendingDelete] = useState<ViolationRecord | null>(null);
 
-  const rows = useMemo(() => {
-    return violations.filter((item) => {
-      if (item.type !== tab) return false;
-      if (namespaceKeyword && !item.namespace.toLowerCase().includes(namespaceKeyword.toLowerCase())) {
-        return false;
+  const rows = data.list;
+  const totalPages = data.totalPages;
+
+  const loadViolations = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const nextData = await listViolationRecordsPage({
+        type: tab,
+        scope,
+        page,
+        keyword,
+        timeRange,
+      });
+      if (nextData.totalPages > 0 && page > nextData.totalPages) {
+        setPage(nextData.totalPages);
+        return;
       }
-      return true;
-    });
-  }, [namespaceKeyword, tab, violations]);
+      setData(nextData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "违规数据加载失败");
+      setData({
+        list: [],
+        total: 0,
+        page,
+        pageSize: 10,
+        totalPages: 0,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [keyword, page, scope, tab, timeRange]);
+
+  useEffect(() => {
+    void loadViolations();
+  }, [loadViolations]);
+
+  function resetPage(nextAction: () => void) {
+    nextAction();
+    setPage(1);
+  }
+
+  function handleSearchSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    resetPage(() => setKeyword(keywordInput.trim()));
+  }
 
   return (
     <div className="page-container">
       <PageHeader
         kicker="Risk Center"
         title="违规中心"
-        description="在同一套布局里查看内容违规和进程违规两类记录。"
+        description="按范围、时间和关键词查看检测记录。"
         actions={
           <Button
             variant="secondary"
             onClick={() => {
-              void refreshAll();
+              void loadViolations();
             }}
           >
             <RefreshCw size={16} /> 刷新
@@ -55,28 +106,63 @@ export function ViolationsPage() {
       />
 
       <SurfaceCard>
-        <div className="toolbar">
-          <Field label="namespace">
-            <Input placeholder="按 namespace 搜索" value={namespaceKeyword} onChange={(event) => setNamespaceKeyword(event.target.value)} />
+        <form className="toolbar" onSubmit={handleSearchSubmit}>
+          <Field label="范围">
+            <Select
+              value={scope}
+              onChange={(event) => {
+                resetPage(() => setScope(event.target.value as ViolationScope));
+              }}
+            >
+              <option value="violations">违规</option>
+              <option value="all">全部</option>
+            </Select>
           </Field>
           <Field label="时间范围">
-            <Select defaultValue="7d">
+            <Select
+              value={timeRange}
+              onChange={(event) => {
+                resetPage(() => setTimeRange(event.target.value as ViolationTimeRange));
+              }}
+            >
               <option value="24h">最近 24 小时</option>
               <option value="7d">最近 7 天</option>
               <option value="30d">最近 30 天</option>
+              <option value="all">全部时间</option>
             </Select>
           </Field>
-          <Field label="关键字">
-            <Input placeholder="detector / process / message" />
+          <Field label="搜索">
+            <div className="search-control">
+              <Input
+                placeholder={tab === "complik" ? "namespace / detector / URL" : "namespace / process / message"}
+                value={keywordInput}
+                onChange={(event) => setKeywordInput(event.target.value)}
+              />
+              <Button variant="secondary" type="submit">
+                <Search size={16} /> 搜索
+              </Button>
+            </div>
           </Field>
-        </div>
+        </form>
       </SurfaceCard>
 
       <div className="tab-row" role="tablist" aria-label="违规类型">
-        <button className={`tab-button ${tab === "complik" ? "active" : ""}`} onClick={() => setTab("complik")} type="button">
+        <button
+          className={`tab-button ${tab === "complik" ? "active" : ""}`}
+          onClick={() => {
+            resetPage(() => setTab("complik"));
+          }}
+          type="button"
+        >
           内容违规
         </button>
-        <button className={`tab-button ${tab === "procscan" ? "active" : ""}`} onClick={() => setTab("procscan")} type="button">
+        <button
+          className={`tab-button ${tab === "procscan" ? "active" : ""}`}
+          onClick={() => {
+            resetPage(() => setTab("procscan"));
+          }}
+          type="button"
+        >
           进程违规
         </button>
       </div>
@@ -91,7 +177,7 @@ export function ViolationsPage() {
                 <Button
                   variant="secondary"
                   onClick={() => {
-                    void refreshAll();
+                    void loadViolations();
                   }}
                 >
                   重新加载
@@ -154,12 +240,20 @@ export function ViolationsPage() {
         ) : (
           <div style={{ padding: 20 }}>
             <EmptyState
-              title="当前筛选条件下没有违规记录"
-              description="可以切换页签、清空筛选，或等待后端同步更多数据。"
+              title="当前筛选条件下没有检测记录"
+              description="可以切换范围、时间或搜索词查看其他记录。"
             />
           </div>
         )}
       </SurfaceCard>
+
+      <PaginationControls
+        page={page}
+        pageSize={data.pageSize}
+        total={data.total}
+        totalPages={totalPages}
+        onPageChange={setPage}
+      />
 
       <Drawer
         description="点开记录后停留在当前页，右侧抽屉展示完整字段。"
@@ -209,14 +303,12 @@ export function ViolationsPage() {
         onClose={() => setPendingDelete(null)}
         onConfirm={() => {
           if (!pendingDelete) return;
-          void deleteViolationRecord({
-            id: pendingDelete.apiId,
-            type: pendingDelete.type,
-          }).then(() => {
+          void apiDeleteViolationRecord(pendingDelete.apiId, pendingDelete.type).then(() => {
             if (selected?.id === pendingDelete.id) {
               setSelected(null);
             }
             setPendingDelete(null);
+            void loadViolations();
           });
         }}
         open={Boolean(pendingDelete)}

--- a/sealos-complik-admin/web/src/styles.css
+++ b/sealos-complik-admin/web/src/styles.css
@@ -360,6 +360,7 @@ table {
   border-radius: var(--radius-sm);
   padding: 0 18px;
   font-weight: 600;
+  white-space: nowrap;
   border: 1px solid transparent;
   transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
@@ -377,6 +378,12 @@ table {
 
 .btn:hover {
   transform: translateY(-1px);
+}
+
+.btn:disabled {
+  cursor: default;
+  opacity: 0.52;
+  transform: none;
 }
 
 .btn-primary {
@@ -457,6 +464,34 @@ table {
 }
 
 .field-label {
+  font-weight: 600;
+}
+
+.search-control {
+  display: flex;
+  gap: 10px;
+}
+
+.search-control .btn {
+  flex: 0 0 auto;
+}
+
+.search-control .input {
+  min-width: 260px;
+}
+
+.pagination-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.pagination-label {
+  display: inline-flex;
+  align-items: center;
+  min-height: 42px;
+  color: var(--color-muted);
   font-weight: 600;
 }
 
@@ -1120,6 +1155,16 @@ table {
 
   .field {
     min-width: 100%;
+  }
+
+  .search-control,
+  .pagination-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-control .input {
+    min-width: 0;
   }
 
   .surface-card.padded,

--- a/sealos-complik-admin/web/src/types.ts
+++ b/sealos-complik-admin/web/src/types.ts
@@ -31,6 +31,10 @@ export type QuickLinkItem = {
 
 export type ViolationType = "complik" | "procscan";
 
+export type ViolationScope = "violations" | "all";
+
+export type ViolationTimeRange = "24h" | "7d" | "30d" | "all";
+
 export type ViolationRecord = {
   id: string;
   apiId: number;
@@ -161,6 +165,36 @@ export type CreateUnbanInput = {
 export type DeleteViolationInput = {
   id: number;
   type: ViolationType;
+};
+
+export type ViolationListQuery = {
+  type: ViolationType;
+  scope: ViolationScope;
+  page: number;
+  keyword: string;
+  timeRange: ViolationTimeRange;
+};
+
+export type PaginatedViolationRecords = {
+  list: ViolationRecord[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+};
+
+export type PaginatedRecords<T> = {
+  list: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+};
+
+export type RecordListQuery = {
+  page: number;
+  keyword?: string;
+  operatorName?: string;
 };
 
 export type AppDataContextValue = {


### PR DESCRIPTION
## Summary

- Add paginated admin APIs
- Add filters for all/violations, keyword, and time range
- Paginate admin web views
- Add dark background styling
- Update namespace detail default state

## Test

- go test ./...
- npm run build