### PR TITLE
feat: add VLog path discovery and aggregate Lark alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .superpowers/
 .fork-skill/
 codex-work/
+analyse/

--- a/complik/cmd/complik/main.go
+++ b/complik/cmd/complik/main.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/bearslyricattack/CompliK/complik/plugins/discovery/informer/deployment"
 	_ "github.com/bearslyricattack/CompliK/complik/plugins/discovery/informer/endPointSlice"
 	_ "github.com/bearslyricattack/CompliK/complik/plugins/discovery/informer/statefulset"
+	_ "github.com/bearslyricattack/CompliK/complik/plugins/discovery/vlogpath"
 	_ "github.com/bearslyricattack/CompliK/complik/plugins/handle/admin/reporter"
 	_ "github.com/bearslyricattack/CompliK/complik/plugins/handle/lark"
 )

--- a/complik/config.yml
+++ b/complik/config.yml
@@ -42,6 +42,36 @@ plugins:
         "ageThresholdSecond": 300
       }
 
+  - name: "VLogPathDiscovery"
+    type: "Discovery"
+    enabled: false
+    settings: |
+      {
+        "logServerPath": "${VLOG_LOG_SERVER_PATH}",
+        "username": "${VLOG_USERNAME}",
+        "password": "${VLOG_PASSWORD}",
+        "app": "higress",
+        "intervalHour": 6,
+        "lookbackHour": 24,
+        "bucketHour": 1,
+        "topNPerHost": 50,
+        "queryLimitPerBucket": 50,
+        "maxGroupsPerRun": 500,
+        "queryConcurrency": 3,
+        "runTimeoutSecond": 900,
+        "resyncTimeSecond": 30,
+        "namespacePrefix": "ns-",
+        "fields": {
+          "time": "_time",
+          "host": "host",
+          "path": "path",
+          "method": "method",
+          "statusCode": "status_code",
+          "responseContentType": "response_content_type"
+        },
+        "contentTypeAllowlist": ["text/html", "application/xhtml+xml"]
+      }
+
   - name: "Browser"
     type: "Compliance"
     enabled: true
@@ -82,6 +112,9 @@ plugins:
     settings: |
       {
         "region": "${REGION}",
+        "aggregationWindowSecond": 300,
+        "maxAggregationBuckets": 1000,
+        "maxPathsPerBucket": 50,
         "adminBaseURL": "http://sealos-complik-admin:8080",
         "adminTimeoutSecond": 10,
         "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",

--- a/complik/deploy/deploy/charts/complik/templates/configmap.yaml
+++ b/complik/deploy/deploy/charts/complik/templates/configmap.yaml
@@ -46,6 +46,28 @@ data:
             "resyncTimeSecond": {{ .Values.plugins.statefulset.resyncTimeSecond }},
             "ageThresholdSecond": {{ .Values.plugins.statefulset.ageThresholdSecond }}
           }
+      - name: "VLogPathDiscovery"
+        type: "Discovery"
+        enabled: {{ .Values.plugins.vlogPathDiscovery.enabled }}
+        settings: |
+          {
+            "logServerPath": {{ .Values.plugins.vlogPathDiscovery.logServerPath | quote }},
+            "username": {{ .Values.plugins.vlogPathDiscovery.username | quote }},
+            "password": {{ .Values.plugins.vlogPathDiscovery.password | quote }},
+            "app": {{ .Values.plugins.vlogPathDiscovery.app | quote }},
+            "intervalHour": {{ .Values.plugins.vlogPathDiscovery.intervalHour }},
+            "lookbackHour": {{ .Values.plugins.vlogPathDiscovery.lookbackHour }},
+            "bucketHour": {{ .Values.plugins.vlogPathDiscovery.bucketHour }},
+            "topNPerHost": {{ .Values.plugins.vlogPathDiscovery.topNPerHost }},
+            "queryLimitPerBucket": {{ .Values.plugins.vlogPathDiscovery.queryLimitPerBucket }},
+            "maxGroupsPerRun": {{ .Values.plugins.vlogPathDiscovery.maxGroupsPerRun }},
+            "queryConcurrency": {{ .Values.plugins.vlogPathDiscovery.queryConcurrency }},
+            "runTimeoutSecond": {{ .Values.plugins.vlogPathDiscovery.runTimeoutSecond }},
+            "resyncTimeSecond": {{ .Values.plugins.vlogPathDiscovery.resyncTimeSecond }},
+            "namespacePrefix": {{ .Values.plugins.vlogPathDiscovery.namespacePrefix | quote }},
+            "fields": {{ .Values.plugins.vlogPathDiscovery.fields | toJson }},
+            "contentTypeAllowlist": {{ .Values.plugins.vlogPathDiscovery.contentTypeAllowlist | toJson }}
+          }
       - name: "Browser"
         type: "Compliance"
         enabled: {{ .Values.plugins.browser.enabled }}
@@ -83,6 +105,9 @@ data:
         settings: |
           {
             "region": {{ .Values.external.region | quote }},
+            "aggregationWindowSecond": {{ .Values.plugins.lark.aggregationWindowSecond }},
+            "maxAggregationBuckets": {{ .Values.plugins.lark.maxAggregationBuckets }},
+            "maxPathsPerBucket": {{ .Values.plugins.lark.maxPathsPerBucket }},
             "adminBaseURL": {{ .Values.external.admin.baseURL | quote }},
             "adminTimeoutSecond": {{ .Values.external.admin.timeoutSecond }},
             "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",

--- a/complik/deploy/deploy/charts/complik/values.yaml
+++ b/complik/deploy/deploy/charts/complik/values.yaml
@@ -70,6 +70,33 @@ plugins:
     resyncTimeSecond: 5
     ageThresholdSecond: 300
 
+  vlogPathDiscovery:
+    enabled: false
+    logServerPath: ""
+    username: ""
+    password: ""
+    app: higress
+    intervalHour: 6
+    lookbackHour: 24
+    bucketHour: 1
+    topNPerHost: 50
+    queryLimitPerBucket: 50
+    maxGroupsPerRun: 500
+    queryConcurrency: 3
+    runTimeoutSecond: 900
+    resyncTimeSecond: 30
+    namespacePrefix: ns-
+    fields:
+      time: _time
+      host: host
+      path: path
+      method: method
+      statusCode: status_code
+      responseContentType: response_content_type
+    contentTypeAllowlist:
+      - text/html
+      - application/xhtml+xml
+
   browser:
     enabled: true
     timeout: 100
@@ -91,6 +118,9 @@ plugins:
 
   lark:
     enabled: true
+    aggregationWindowSecond: 300
+    maxAggregationBuckets: 1000
+    maxPathsPerBucket: 50
 
 config:
   logging:

--- a/complik/deploy/manifests/deploy.yaml
+++ b/complik/deploy/manifests/deploy.yaml
@@ -51,6 +51,36 @@ data:
             "ageThresholdSecond": 300
           }
 
+      - name: "VLogPathDiscovery"
+        type: "Discovery"
+        enabled: false
+        settings: |
+          {
+            "logServerPath": "${VLOG_LOG_SERVER_PATH}",
+            "username": "${VLOG_USERNAME}",
+            "password": "${VLOG_PASSWORD}",
+            "app": "higress",
+            "intervalHour": 6,
+            "lookbackHour": 24,
+            "bucketHour": 1,
+            "topNPerHost": 50,
+            "queryLimitPerBucket": 50,
+            "maxGroupsPerRun": 500,
+            "queryConcurrency": 3,
+            "runTimeoutSecond": 900,
+            "resyncTimeSecond": 30,
+            "namespacePrefix": "ns-",
+            "fields": {
+              "time": "_time",
+              "host": "host",
+              "path": "path",
+              "method": "method",
+              "statusCode": "status_code",
+              "responseContentType": "response_content_type"
+            },
+            "contentTypeAllowlist": ["text/html", "application/xhtml+xml"]
+          }
+
       - name: "Browser"
         type: "Compliance"
         enabled: true
@@ -91,6 +121,9 @@ data:
         settings: |
           {
             "region": "hzh",
+            "aggregationWindowSecond": 300,
+            "maxAggregationBuckets": 1000,
+            "maxPathsPerBucket": 50,
             "adminBaseURL": "http://sealos-complik-admin:8080",
             "adminTimeoutSecond": 10,
             "adminBasicAuthUsername": "${ADMIN_BASIC_AUTH_USERNAME}",

--- a/complik/pkg/constants/pluginName.go
+++ b/complik/pkg/constants/pluginName.go
@@ -23,6 +23,7 @@ const (
 	DiscoveryInformerEndPointSliceName   = "Endpointslice"
 	DiscoveryInformerServiceNodePortName = "NodePort"
 	DiscoveryInformerIngressName         = "Ingress"
+	DiscoveryVLogPathName                = "VLogPathDiscovery"
 )
 
 const (

--- a/complik/pkg/eventbus/eventbus.go
+++ b/complik/pkg/eventbus/eventbus.go
@@ -75,6 +75,7 @@ func (eb *EventBus) Subscribe(topic string) EventChan {
 // Unsubscribe removes a subscription from the specified topic and closes the channel
 func (eb *EventBus) Unsubscribe(topic string, ch EventChan) {
 	eb.mu.Lock()
+
 	found := false
 	if subscribers, ok := eb.subscribers[topic]; ok {
 		for i, subscriber := range subscribers {
@@ -92,6 +93,7 @@ func (eb *EventBus) Unsubscribe(topic string, ch EventChan) {
 	}
 
 	close(ch)
+
 	for range ch {
 	}
 }

--- a/complik/pkg/eventbus/eventbus.go
+++ b/complik/pkg/eventbus/eventbus.go
@@ -75,20 +75,23 @@ func (eb *EventBus) Subscribe(topic string) EventChan {
 // Unsubscribe removes a subscription from the specified topic and closes the channel
 func (eb *EventBus) Unsubscribe(topic string, ch EventChan) {
 	eb.mu.Lock()
-	defer eb.mu.Unlock()
-
+	found := false
 	if subscribers, ok := eb.subscribers[topic]; ok {
 		for i, subscriber := range subscribers {
 			if ch == subscriber {
 				eb.subscribers[topic] = append(subscribers[:i], subscribers[i+1:]...)
-
-				close(ch)
-
-				for range ch {
-				}
-
-				return
+				found = true
+				break
 			}
 		}
+	}
+	eb.mu.Unlock()
+
+	if !found {
+		return
+	}
+
+	close(ch)
+	for range ch {
 	}
 }

--- a/complik/pkg/utils/config/admin_project_config.go
+++ b/complik/pkg/utils/config/admin_project_config.go
@@ -49,8 +49,11 @@ type ModelRuntimeConfig struct {
 }
 
 type NotificationsRuntimeConfig struct {
-	Region  string `json:"region"`
-	Webhook string `json:"webhook"`
+	Region                  string `json:"region"`
+	Webhook                 string `json:"webhook"`
+	AggregationWindowSecond int    `json:"aggregationWindowSecond"`
+	MaxAggregationBuckets   int    `json:"maxAggregationBuckets"`
+	MaxPathsPerBucket       int    `json:"maxPathsPerBucket"`
 }
 
 func (c *AdminProjectConfig) DecodeValue(dst any) error {

--- a/complik/plugins/discovery/vlogpath/cache.go
+++ b/complik/plugins/discovery/vlogpath/cache.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:wsl_v5 // Discovery cache code keeps related Kubernetes branches compact.
 package vlogpath
 
 import (

--- a/complik/plugins/discovery/vlogpath/cache.go
+++ b/complik/plugins/discovery/vlogpath/cache.go
@@ -1,0 +1,397 @@
+// Copyright 2025 CompliK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vlogpath
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bearslyricattack/CompliK/complik/pkg/k8s"
+	"github.com/bearslyricattack/CompliK/complik/pkg/logger"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// SeedPathInfo captures the Ingress path that acts as the trusted starting
+// point for log-derived child path discovery.
+type SeedPathInfo struct {
+	DiscoveryName string
+	Namespace     string
+	IngressName   string
+	Host          string
+	IngressPath   string
+	ServiceName   string
+	HasActivePods bool
+	PodCount      int
+	UpdatedAt     time.Time
+}
+
+// SeedPathGroup batches seed paths by namespace and host so each VLog host
+// query can be matched against only the relevant Ingress routes.
+type SeedPathGroup struct {
+	Namespace string
+	Host      string
+	Seeds     []SeedPathInfo
+}
+
+// Match returns the most specific seed path that contains candidatePath.
+func (g SeedPathGroup) Match(candidatePath string) (SeedPathInfo, bool) {
+	var matched SeedPathInfo
+	found := false
+
+	for _, seed := range g.Seeds {
+		if !IsChildPath(seed.IngressPath, candidatePath) {
+			continue
+		}
+
+		if !found || len(seed.IngressPath) > len(matched.IngressPath) {
+			matched = seed
+			found = true
+		}
+	}
+
+	return matched, found
+}
+
+// SeedCache stores the current Ingress-derived seed paths keyed by
+// namespace/host and keeps informer updates safe for concurrent scanner reads.
+type SeedCache struct {
+	mu    sync.RWMutex
+	items map[string][]SeedPathInfo
+}
+
+func NewSeedCache() *SeedCache {
+	return &SeedCache{
+		items: make(map[string][]SeedPathInfo),
+	}
+}
+
+func (c *SeedCache) UpsertIngress(namespace, ingressName string, seeds []SeedPathInfo) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Replace the whole Ingress snapshot so removed paths disappear from future
+	// discovery runs after an update event.
+	c.deleteIngressLocked(namespace, ingressName)
+	for _, seed := range seeds {
+		key := seedCacheKey(seed.Namespace, seed.Host)
+		c.items[key] = append(c.items[key], seed)
+	}
+}
+
+func (c *SeedCache) DeleteIngress(namespace, ingressName string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.deleteIngressLocked(namespace, ingressName)
+}
+
+func (c *SeedCache) Groups() []SeedPathGroup {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// Return copied, sorted groups so callers can rank/match without holding the
+	// cache lock and without mutating stored state.
+	groups := make([]SeedPathGroup, 0, len(c.items))
+	for key, seeds := range c.items {
+		if len(seeds) == 0 {
+			continue
+		}
+
+		namespace, host := parseSeedCacheKey(key)
+		copied := append([]SeedPathInfo(nil), seeds...)
+		sort.SliceStable(copied, func(i, j int) bool {
+			if len(copied[i].IngressPath) == len(copied[j].IngressPath) {
+				return copied[i].IngressPath < copied[j].IngressPath
+			}
+
+			return len(copied[i].IngressPath) > len(copied[j].IngressPath)
+		})
+
+		groups = append(groups, SeedPathGroup{
+			Namespace: namespace,
+			Host:      host,
+			Seeds:     copied,
+		})
+	}
+
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].Namespace == groups[j].Namespace {
+			return groups[i].Host < groups[j].Host
+		}
+
+		return groups[i].Namespace < groups[j].Namespace
+	})
+
+	return groups
+}
+
+func (c *SeedCache) deleteIngressLocked(namespace, ingressName string) {
+	// Filter in place to reduce allocations while rebuilding each host group.
+	for key, seeds := range c.items {
+		filtered := seeds[:0]
+		for _, seed := range seeds {
+			if seed.Namespace == namespace && seed.IngressName == ingressName {
+				continue
+			}
+
+			filtered = append(filtered, seed)
+		}
+
+		if len(filtered) == 0 {
+			delete(c.items, key)
+			continue
+		}
+
+		c.items[key] = filtered
+	}
+}
+
+func seedCacheKey(namespace, host string) string {
+	// NUL separates fields because Kubernetes namespaces and DNS hosts cannot
+	// contain it, making the key reversible without escaping.
+	return namespace + "\x00" + host
+}
+
+func parseSeedCacheKey(key string) (string, string) {
+	parts := strings.SplitN(key, "\x00", 2)
+	if len(parts) != 2 {
+		return "", key
+	}
+
+	return parts[0], parts[1]
+}
+
+func (p *VLogPathPlugin) startIngressInformer(ctx context.Context) {
+	// The informer is the authoritative source for seed paths; log-derived paths
+	// are published only when they extend a currently observed Ingress route.
+	if k8s.ClientSet == nil {
+		p.log.Error("Kubernetes client is nil, VLogPathDiscovery informer cannot start")
+		return
+	}
+
+	factory := informers.NewSharedInformerFactory(
+		k8s.ClientSet,
+		time.Duration(p.vlogPathConfig.ResyncTimeSecond)*time.Second,
+	)
+	p.factory = factory
+
+	p.ingressInformer = factory.Networking().V1().Ingresses().Informer()
+
+	_, err := p.ingressInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			ingress, ok := obj.(*networkingv1.Ingress)
+			if !ok {
+				p.log.Error("Failed to cast object to Ingress", logger.Fields{
+					"object_type": fmt.Sprintf("%T", obj),
+				})
+				return
+			}
+
+			p.upsertIngressSeeds(ctx, ingress)
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			ingress, ok := newObj.(*networkingv1.Ingress)
+			if !ok {
+				p.log.Error("Failed to cast updated object to Ingress", logger.Fields{
+					"object_type": fmt.Sprintf("%T", newObj),
+				})
+				return
+			}
+
+			p.upsertIngressSeeds(ctx, ingress)
+		},
+		DeleteFunc: func(obj any) {
+			ingress, ok := obj.(*networkingv1.Ingress)
+			if !ok {
+				tombstone, tombstoneOK := obj.(cache.DeletedFinalStateUnknown)
+				if tombstoneOK {
+					ingress, ok = tombstone.Obj.(*networkingv1.Ingress)
+				}
+			}
+			if !ok {
+				p.log.Error("Failed to cast deleted object to Ingress", logger.Fields{
+					"object_type": fmt.Sprintf("%T", obj),
+				})
+				return
+			}
+
+			p.seedCache.DeleteIngress(ingress.Namespace, ingress.Name)
+		},
+	})
+	if err != nil {
+		p.log.Error("Failed to add Ingress event handler", logger.Fields{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	p.factory.Start(p.stopChan)
+
+	if !cache.WaitForCacheSync(p.stopChan, p.ingressInformer.HasSynced) {
+		p.log.Error("Failed to wait for VLogPathDiscovery ingress cache sync")
+		return
+	}
+
+	p.log.Info("VLogPathDiscovery ingress informer started")
+
+	select {
+	case <-ctx.Done():
+	case <-p.stopChan:
+	}
+}
+
+func (p *VLogPathPlugin) upsertIngressSeeds(ctx context.Context, ingress *networkingv1.Ingress) {
+	if ingress == nil {
+		return
+	}
+
+	// Namespace filtering keeps discovery scoped to tenant namespaces configured
+	// for compliance checks.
+	if !p.shouldProcessIngress(ingress) {
+		p.seedCache.DeleteIngress(ingress.Namespace, ingress.Name)
+		return
+	}
+
+	seeds, err := p.buildSeedPaths(ctx, ingress)
+	if err != nil {
+		p.log.Error("Failed to build VLog seed paths", logger.Fields{
+			"namespace": ingress.Namespace,
+			"ingress":   ingress.Name,
+			"error":     err.Error(),
+		})
+		return
+	}
+
+	p.seedCache.UpsertIngress(ingress.Namespace, ingress.Name, seeds)
+	p.log.Debug("Updated VLog seed paths", logger.Fields{
+		"namespace": ingress.Namespace,
+		"ingress":   ingress.Name,
+		"count":     len(seeds),
+	})
+}
+
+func (p *VLogPathPlugin) shouldProcessIngress(ingress *networkingv1.Ingress) bool {
+	if ingress == nil {
+		return false
+	}
+
+	if p.vlogPathConfig.NamespacePrefix == "" {
+		return true
+	}
+
+	return strings.HasPrefix(ingress.Namespace, p.vlogPathConfig.NamespacePrefix)
+}
+
+func (p *VLogPathPlugin) buildSeedPaths(
+	ctx context.Context,
+	ingress *networkingv1.Ingress,
+) ([]SeedPathInfo, error) {
+	// EndpointSlice data annotates each seed with live backend health, matching
+	// the discovery payload shape produced by the informer plugins.
+	endpointSlices, err := k8s.ClientSet.DiscoveryV1().
+		EndpointSlices(ingress.Namespace).
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list EndpointSlices: %w", err)
+	}
+
+	endpointSlicesMap := buildEndpointSlicesMap(endpointSlices)
+
+	seeds := make([]SeedPathInfo, 0)
+	for _, rule := range ingress.Spec.Rules {
+		host := strings.TrimSpace(rule.Host)
+		if host == "" || host == "*" || rule.HTTP == nil {
+			continue
+		}
+
+		for _, path := range rule.HTTP.Paths {
+			serviceName := ""
+			if path.Backend.Service != nil {
+				serviceName = path.Backend.Service.Name
+			}
+
+			normalizedSeedPath, ok := NormalizePath(path.Path)
+			if !ok {
+				continue
+			}
+
+			hasActivePods, podCount := endpointInfo(endpointSlicesMap, serviceName)
+			seeds = append(seeds, SeedPathInfo{
+				DiscoveryName: p.Name(),
+				Namespace:     ingress.Namespace,
+				IngressName:   ingress.Name,
+				Host:          host,
+				IngressPath:   normalizedSeedPath,
+				ServiceName:   serviceName,
+				HasActivePods: hasActivePods,
+				PodCount:      podCount,
+				UpdatedAt:     time.Now(),
+			})
+		}
+	}
+
+	return seeds, nil
+}
+
+func buildEndpointSlicesMap(
+	list *discoveryv1.EndpointSliceList,
+) map[string][]discoveryv1.EndpointSlice {
+	// Group EndpointSlices by owning Service so each Ingress backend can be
+	// checked with a constant-time map lookup.
+	result := make(map[string][]discoveryv1.EndpointSlice)
+	if list == nil {
+		return result
+	}
+
+	for _, endpointSlice := range list.Items {
+		serviceName := endpointSlice.Labels[discoveryv1.LabelServiceName]
+		if serviceName == "" {
+			continue
+		}
+
+		result[serviceName] = append(result[serviceName], endpointSlice)
+	}
+
+	return result
+}
+
+func endpointInfo(
+	endpointSlices map[string][]discoveryv1.EndpointSlice,
+	serviceName string,
+) (bool, int) {
+	// Ready endpoints represent pods that can currently serve the Ingress path.
+	if serviceName == "" {
+		return false, 0
+	}
+
+	readyPodCount := 0
+	for _, endpointSlice := range endpointSlices[serviceName] {
+		for _, endpoint := range endpointSlice.Endpoints {
+			if endpoint.Conditions.Ready != nil && *endpoint.Conditions.Ready {
+				readyPodCount++
+			}
+		}
+	}
+
+	return readyPodCount > 0, readyPodCount
+}

--- a/complik/plugins/discovery/vlogpath/path.go
+++ b/complik/plugins/discovery/vlogpath/path.go
@@ -1,0 +1,212 @@
+// Copyright 2025 CompliK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vlogpath
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+const maxNormalizedPathLength = 1024
+
+// CandidatePath is a log-derived child path plus the seed Ingress path that
+// proves the host and route belong to a tracked workload.
+type CandidatePath struct {
+	Seed             SeedPathInfo
+	Path             string
+	Count            int
+	LatestAccessTime time.Time
+}
+
+// NormalizeContentType strips parameters such as charset and lowercases the
+// media type so allowlist checks can compare stable values.
+func NormalizeContentType(value string) string {
+	contentType := strings.ToLower(strings.TrimSpace(value))
+	if idx := strings.Index(contentType, ";"); idx >= 0 {
+		contentType = contentType[:idx]
+	}
+
+	return strings.TrimSpace(contentType)
+}
+
+func normalizeContentTypes(values []string) []string {
+	// Deduplicate after normalization so config can be written naturally while
+	// runtime comparisons stay small and predictable.
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+
+	for _, value := range values {
+		item := NormalizeContentType(value)
+		if item == "" {
+			continue
+		}
+
+		if _, exists := seen[item]; exists {
+			continue
+		}
+
+		seen[item] = struct{}{}
+		normalized = append(normalized, item)
+	}
+
+	return normalized
+}
+
+func isAllowedContentType(value string, allowlist []string) bool {
+	// Empty content types are treated as unknown responses and skipped.
+	contentType := NormalizeContentType(value)
+	if contentType == "" {
+		return false
+	}
+
+	for _, allowed := range allowlist {
+		if contentType == NormalizeContentType(allowed) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// NormalizePath extracts the URL path, decodes it once, removes query/fragment
+// data, and normalizes slash/trailing-slash variants for reliable comparison.
+func NormalizePath(value string) (string, bool) {
+	pathValue := strings.TrimSpace(value)
+	if pathValue == "" {
+		return "/", true
+	}
+
+	if parsed, err := url.Parse(pathValue); err == nil {
+		if parsed.Path != "" {
+			pathValue = parsed.Path
+		}
+	}
+
+	if idx := strings.Index(pathValue, "?"); idx >= 0 {
+		pathValue = pathValue[:idx]
+	}
+	if idx := strings.Index(pathValue, "#"); idx >= 0 {
+		pathValue = pathValue[:idx]
+	}
+
+	if decoded, err := url.PathUnescape(pathValue); err == nil {
+		pathValue = decoded
+	}
+
+	pathValue = strings.TrimSpace(pathValue)
+	if pathValue == "" {
+		pathValue = "/"
+	}
+
+	if !strings.HasPrefix(pathValue, "/") {
+		pathValue = "/" + pathValue
+	}
+
+	for strings.Contains(pathValue, "//") {
+		pathValue = strings.ReplaceAll(pathValue, "//", "/")
+	}
+
+	// Keep "/" intact while making "/foo/" and "/foo" compare as one path.
+	if len(pathValue) > 1 {
+		pathValue = strings.TrimRight(pathValue, "/")
+	}
+
+	if len(pathValue) > maxNormalizedPathLength {
+		return "", false
+	}
+
+	return pathValue, true
+}
+
+// IsChildPath reports whether candidatePath is below seedPath after applying
+// the same normalization rules to both sides.
+func IsChildPath(seedPath, candidatePath string) bool {
+	seed, seedOK := NormalizePath(seedPath)
+	candidate, candidateOK := NormalizePath(candidatePath)
+	if !seedOK || !candidateOK {
+		return false
+	}
+
+	if seed == candidate {
+		return false
+	}
+
+	if seed == "/" {
+		return candidate != "/"
+	}
+
+	return strings.HasPrefix(candidate, seed+"/")
+}
+
+// RankCandidates prioritizes security-sensitive prefixes, then frequent and
+// recent paths, and finally path name for deterministic ties.
+func RankCandidates(
+	items []CandidatePath,
+	limit int,
+	highRiskPrefixes []string,
+) []CandidatePath {
+	if limit <= 0 || len(items) == 0 {
+		return nil
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		iRisk := highRiskScore(items[i].Path, highRiskPrefixes)
+		jRisk := highRiskScore(items[j].Path, highRiskPrefixes)
+		if iRisk != jRisk {
+			return iRisk > jRisk
+		}
+
+		if items[i].Count != items[j].Count {
+			return items[i].Count > items[j].Count
+		}
+
+		if !items[i].LatestAccessTime.Equal(items[j].LatestAccessTime) {
+			return items[i].LatestAccessTime.After(items[j].LatestAccessTime)
+		}
+
+		return items[i].Path < items[j].Path
+	})
+
+	if len(items) > limit {
+		return items[:limit]
+	}
+
+	return items
+}
+
+func highRiskScore(path string, prefixes []string) int {
+	// Longer matching prefixes win, so a specific "/admin/pay" prefix outranks
+	// a broader "/admin" prefix when both are configured.
+	score := 0
+	normalizedPath, ok := NormalizePath(path)
+	if !ok {
+		return score
+	}
+
+	for _, prefix := range prefixes {
+		normalizedPrefix, prefixOK := NormalizePath(prefix)
+		if !prefixOK {
+			continue
+		}
+
+		if normalizedPath == normalizedPrefix || strings.HasPrefix(normalizedPath, normalizedPrefix+"/") {
+			score = max(score, len(normalizedPrefix))
+		}
+	}
+
+	return score
+}

--- a/complik/plugins/discovery/vlogpath/path.go
+++ b/complik/plugins/discovery/vlogpath/path.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:wsl_v5 // Path normalization and ranking keep related checks compact.
 package vlogpath
 
 import (
@@ -203,7 +204,8 @@ func highRiskScore(path string, prefixes []string) int {
 			continue
 		}
 
-		if normalizedPath == normalizedPrefix || strings.HasPrefix(normalizedPath, normalizedPrefix+"/") {
+		if normalizedPath == normalizedPrefix ||
+			strings.HasPrefix(normalizedPath, normalizedPrefix+"/") {
 			score = max(score, len(normalizedPrefix))
 		}
 	}

--- a/complik/plugins/discovery/vlogpath/path_test.go
+++ b/complik/plugins/discovery/vlogpath/path_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:testpackage,wsl_v5 // Tests exercise unexported ranking and config helpers.
 package vlogpath
 
 import (
@@ -26,7 +27,11 @@ func TestNormalizeContentType(t *testing.T) {
 		want string
 	}{
 		{name: "html charset", in: "text/html; charset=utf-8", want: "text/html"},
-		{name: "xhtml charset", in: "application/xhtml+xml; charset=utf-8", want: "application/xhtml+xml"},
+		{
+			name: "xhtml charset",
+			in:   "application/xhtml+xml; charset=utf-8",
+			want: "application/xhtml+xml",
+		},
 		{name: "upper", in: "TEXT/HTML", want: "text/html"},
 	}
 

--- a/complik/plugins/discovery/vlogpath/path_test.go
+++ b/complik/plugins/discovery/vlogpath/path_test.go
@@ -1,0 +1,128 @@
+// Copyright 2025 CompliK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vlogpath
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeContentType(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "html charset", in: "text/html; charset=utf-8", want: "text/html"},
+		{name: "xhtml charset", in: "application/xhtml+xml; charset=utf-8", want: "application/xhtml+xml"},
+		{name: "upper", in: "TEXT/HTML", want: "text/html"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeContentType(tt.in)
+			if got != tt.want {
+				t.Fatalf("NormalizeContentType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		{name: "empty", in: "", want: "/", ok: true},
+		{name: "query fragment", in: "/a//b/?x=1#top", want: "/a/b", ok: true},
+		{name: "decode once", in: "/a/%41", want: "/a/A", ok: true},
+		{name: "missing slash", in: "activity/a", want: "/activity/a", ok: true},
+		{name: "root trailing", in: "/", want: "/", ok: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := NormalizePath(tt.in)
+			if ok != tt.ok {
+				t.Fatalf("NormalizePath() ok = %v, want %v", ok, tt.ok)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizePath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsChildPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		seed      string
+		candidate string
+		want      bool
+	}{
+		{name: "child", seed: "/activity", candidate: "/activity/a", want: true},
+		{name: "same", seed: "/activity", candidate: "/activity", want: false},
+		{name: "prefix sibling", seed: "/activity", candidate: "/activity-other/a", want: false},
+		{name: "root child", seed: "/", candidate: "/login", want: true},
+		{name: "root same", seed: "/", candidate: "/", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsChildPath(tt.seed, tt.candidate)
+			if got != tt.want {
+				t.Fatalf("IsChildPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRankCandidates(t *testing.T) {
+	now := time.Now()
+	items := []CandidatePath{
+		{Path: "/docs/a", Count: 100, LatestAccessTime: now},
+		{Path: "/admin/a", Count: 1, LatestAccessTime: now.Add(-time.Hour)},
+		{Path: "/login", Count: 2, LatestAccessTime: now.Add(time.Hour)},
+	}
+
+	got := RankCandidates(items, 2, []string{"/admin", "/login"})
+	if len(got) != 2 {
+		t.Fatalf("RankCandidates len = %d, want 2", len(got))
+	}
+
+	if got[0].Path != "/login" {
+		t.Fatalf("first candidate = %q, want /login", got[0].Path)
+	}
+
+	if got[1].Path != "/admin/a" {
+		t.Fatalf("second candidate = %q, want /admin/a", got[1].Path)
+	}
+}
+
+func TestDefaultConfigHasLargeClusterGuards(t *testing.T) {
+	cfg := (&VLogPathPlugin{}).getDefaultVLogPathConfig()
+
+	if cfg.MaxGroupsPerRun != 500 {
+		t.Fatalf("MaxGroupsPerRun = %d, want 500", cfg.MaxGroupsPerRun)
+	}
+	if cfg.QueryConcurrency != 3 {
+		t.Fatalf("QueryConcurrency = %d, want 3", cfg.QueryConcurrency)
+	}
+	if cfg.RunTimeoutSecond != 900 {
+		t.Fatalf("RunTimeoutSecond = %d, want 900", cfg.RunTimeoutSecond)
+	}
+}

--- a/complik/plugins/discovery/vlogpath/path_test.go
+++ b/complik/plugins/discovery/vlogpath/path_test.go
@@ -16,6 +16,7 @@
 package vlogpath
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -129,5 +130,24 @@ func TestDefaultConfigHasLargeClusterGuards(t *testing.T) {
 	}
 	if cfg.RunTimeoutSecond != 900 {
 		t.Fatalf("RunTimeoutSecond = %d, want 900", cfg.RunTimeoutSecond)
+	}
+}
+
+func TestBuildQueryUsesConfiguredTimeField(t *testing.T) {
+	client := NewVLogClient(VLogClientConfig{
+		App: "higress-gateway",
+		Fields: VLogFields{
+			Time: "event_time",
+			Host: "authority",
+		},
+	})
+
+	start := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	got := client.buildQuery("example.com", start, end, 100)
+
+	want := `event_time:[2026-06-17T00:00:00Z,2026-06-17T01:00:00Z]`
+	if !strings.Contains(got, want) {
+		t.Fatalf("buildQuery() = %q, want contains %q", got, want)
 	}
 }

--- a/complik/plugins/discovery/vlogpath/path_test.go
+++ b/complik/plugins/discovery/vlogpath/path_test.go
@@ -142,7 +142,7 @@ func TestBuildQueryUsesConfiguredTimeField(t *testing.T) {
 		},
 	})
 
-	start := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+	start := time.Date(2026, time.June, 17, 0, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
 	got := client.buildQuery("example.com", start, end, 100)
 

--- a/complik/plugins/discovery/vlogpath/plugin.go
+++ b/complik/plugins/discovery/vlogpath/plugin.go
@@ -396,14 +396,11 @@ func (p *VLogPathPlugin) processGroups(
 	var wg sync.WaitGroup
 
 	for range concurrency {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			for group := range groupCh {
 				publishedCh <- p.processGroup(ctx, group, windowStart, now, bucketDuration)
 			}
-		}()
+		})
 	}
 
 	go func() {

--- a/complik/plugins/discovery/vlogpath/plugin.go
+++ b/complik/plugins/discovery/vlogpath/plugin.go
@@ -1,0 +1,571 @@
+// Copyright 2025 CompliK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package vlogpath provides a discovery plugin that finds real HTML sub-paths
+// from gateway access logs and publishes them as discovery events.
+package vlogpath
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bearslyricattack/CompliK/complik/pkg/constants"
+	"github.com/bearslyricattack/CompliK/complik/pkg/eventbus"
+	"github.com/bearslyricattack/CompliK/complik/pkg/logger"
+	"github.com/bearslyricattack/CompliK/complik/pkg/models"
+	"github.com/bearslyricattack/CompliK/complik/pkg/plugin"
+	"github.com/bearslyricattack/CompliK/complik/pkg/utils/config"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	pluginName = constants.DiscoveryVLogPathName
+	pluginType = constants.DiscoveryInformerPluginType
+)
+
+func init() {
+	// Register the plugin factory so the manager can create this plugin by name
+	// from config.yml without importing concrete types.
+	plugin.PluginFactories[pluginName] = func() plugin.Plugin {
+		return &VLogPathPlugin{
+			log: logger.GetLogger().WithField("plugin", pluginName),
+		}
+	}
+}
+
+// VLogPathPlugin discovers real page paths from VLog access logs and publishes
+// them through the shared discovery event topic.
+type VLogPathPlugin struct {
+	log             logger.Logger
+	stopChan        chan struct{}
+	eventBus        *eventbus.EventBus
+	factory         informers.SharedInformerFactory
+	ingressInformer cache.SharedIndexInformer
+	vlogPathConfig  VLogPathConfig
+	seedCache       *SeedCache
+	client          *VLogClient
+}
+
+// VLogPathConfig holds all runtime knobs for log querying, seed selection, and
+// candidate ranking.
+type VLogPathConfig struct {
+	LogServerPath        string         `json:"logServerPath"`
+	LogServerPathSnake   string         `json:"log_server_path"`
+	Username             string         `json:"username"`
+	Password             string         `json:"password"`
+	App                  string         `json:"app"`
+	IntervalHour         int            `json:"intervalHour"`
+	LookbackHour         int            `json:"lookbackHour"`
+	BucketHour           int            `json:"bucketHour"`
+	TopNPerHost          int            `json:"topNPerHost"`
+	QueryLimitPerBucket  int            `json:"queryLimitPerBucket"`
+	MaxGroupsPerRun      int            `json:"maxGroupsPerRun"`
+	QueryConcurrency     int            `json:"queryConcurrency"`
+	RunTimeoutSecond     int            `json:"runTimeoutSecond"`
+	HTTPTimeoutSecond    int            `json:"httpTimeoutSecond"`
+	ResyncTimeSecond     int            `json:"resyncTimeSecond"`
+	NamespacePrefix      string         `json:"namespacePrefix"`
+	HighRiskPrefixes     []string       `json:"highRiskPrefixes"`
+	Fields               VLogFields     `json:"fields"`
+	ContentTypeAllowlist []string       `json:"contentTypeAllowlist"`
+	SeedCacheWarmupDelay int            `json:"seedCacheWarmupDelaySecond"`
+	ExtraQueryFilters    map[string]any `json:"extraQueryFilters"`
+}
+
+func (p *VLogPathPlugin) getDefaultVLogPathConfig() VLogPathConfig {
+	// Defaults favor conservative discovery: HTML pages only, a one-day
+	// lookback window, and higher priority for paths that commonly expose risk.
+	return VLogPathConfig{
+		App:                  "higress",
+		IntervalHour:         6,
+		LookbackHour:         24,
+		BucketHour:           1,
+		TopNPerHost:          50,
+		QueryLimitPerBucket:  50,
+		MaxGroupsPerRun:      500,
+		QueryConcurrency:     3,
+		RunTimeoutSecond:     900,
+		HTTPTimeoutSecond:    30,
+		ResyncTimeSecond:     30,
+		NamespacePrefix:      "ns-",
+		HighRiskPrefixes:     []string{"/admin", "/login", "/pay", "/payment", "/promo", "/activity"},
+		Fields:               DefaultVLogFields(),
+		ContentTypeAllowlist: []string{"text/html", "application/xhtml+xml"},
+		SeedCacheWarmupDelay: 5,
+	}
+}
+
+func (p *VLogPathPlugin) Name() string {
+	return pluginName
+}
+
+func (p *VLogPathPlugin) Type() string {
+	return pluginType
+}
+
+// Start loads config, prepares dependencies, then starts the Kubernetes
+// informer and periodic VLog scanner in background goroutines.
+func (p *VLogPathPlugin) Start(
+	ctx context.Context,
+	cfg config.PluginConfig,
+	bus *eventbus.EventBus,
+) error {
+	if err := p.loadConfig(cfg.Settings); err != nil {
+		return err
+	}
+
+	p.eventBus = bus
+	p.stopChan = make(chan struct{})
+	p.seedCache = NewSeedCache()
+	p.client = NewVLogClient(VLogClientConfig{
+		BaseURL:             p.vlogPathConfig.LogServerPath,
+		Username:            p.vlogPathConfig.Username,
+		Password:            p.vlogPathConfig.Password,
+		App:                 p.vlogPathConfig.App,
+		Fields:              p.vlogPathConfig.Fields,
+		HTTPTimeout:         time.Duration(p.vlogPathConfig.HTTPTimeoutSecond) * time.Second,
+		ExtraQueryFilters:   p.vlogPathConfig.ExtraQueryFilters,
+		QueryLimitPerBucket: p.vlogPathConfig.QueryLimitPerBucket,
+	})
+
+	go p.startIngressInformer(ctx)
+	go p.startTicker(ctx)
+
+	return nil
+}
+
+// Stop signals background goroutines to exit through the shared stop channel.
+func (p *VLogPathPlugin) Stop(ctx context.Context) error {
+	if p.stopChan != nil {
+		close(p.stopChan)
+	}
+	return nil
+}
+
+func (p *VLogPathPlugin) loadConfig(setting string) error {
+	// The JSON settings are treated as sparse overrides on top of defaults so
+	// deploy manifests can specify only values that differ per environment.
+	p.vlogPathConfig = p.getDefaultVLogPathConfig()
+	if setting == "" {
+		p.log.Info("Using default VLogPathDiscovery configuration")
+		return nil
+	}
+
+	var configFromJSON VLogPathConfig
+
+	err := json.Unmarshal([]byte(setting), &configFromJSON)
+	if err != nil {
+		p.log.Error("Failed to parse config, using defaults", logger.Fields{
+			"error": err.Error(),
+		})
+		return err
+	}
+
+	if configFromJSON.LogServerPath != "" {
+		p.vlogPathConfig.LogServerPath = configFromJSON.LogServerPath
+	}
+	if configFromJSON.LogServerPathSnake != "" {
+		p.vlogPathConfig.LogServerPath = configFromJSON.LogServerPathSnake
+	}
+	if configFromJSON.Username != "" {
+		p.vlogPathConfig.Username = configFromJSON.Username
+	}
+	if configFromJSON.Password != "" {
+		p.vlogPathConfig.Password = configFromJSON.Password
+	}
+	if configFromJSON.App != "" {
+		p.vlogPathConfig.App = configFromJSON.App
+	}
+	if configFromJSON.IntervalHour > 0 {
+		p.vlogPathConfig.IntervalHour = configFromJSON.IntervalHour
+	}
+	if configFromJSON.LookbackHour > 0 {
+		p.vlogPathConfig.LookbackHour = configFromJSON.LookbackHour
+	}
+	if configFromJSON.BucketHour > 0 {
+		p.vlogPathConfig.BucketHour = configFromJSON.BucketHour
+	}
+	if configFromJSON.TopNPerHost > 0 {
+		p.vlogPathConfig.TopNPerHost = configFromJSON.TopNPerHost
+	}
+	if configFromJSON.QueryLimitPerBucket > 0 {
+		p.vlogPathConfig.QueryLimitPerBucket = configFromJSON.QueryLimitPerBucket
+	}
+	if configFromJSON.MaxGroupsPerRun > 0 {
+		p.vlogPathConfig.MaxGroupsPerRun = configFromJSON.MaxGroupsPerRun
+	}
+	if configFromJSON.QueryConcurrency > 0 {
+		p.vlogPathConfig.QueryConcurrency = configFromJSON.QueryConcurrency
+	}
+	if configFromJSON.RunTimeoutSecond > 0 {
+		p.vlogPathConfig.RunTimeoutSecond = configFromJSON.RunTimeoutSecond
+	}
+	if configFromJSON.HTTPTimeoutSecond > 0 {
+		p.vlogPathConfig.HTTPTimeoutSecond = configFromJSON.HTTPTimeoutSecond
+	}
+	if configFromJSON.ResyncTimeSecond > 0 {
+		p.vlogPathConfig.ResyncTimeSecond = configFromJSON.ResyncTimeSecond
+	}
+	if configFromJSON.NamespacePrefix != "" {
+		p.vlogPathConfig.NamespacePrefix = configFromJSON.NamespacePrefix
+	}
+	if len(configFromJSON.HighRiskPrefixes) > 0 {
+		p.vlogPathConfig.HighRiskPrefixes = configFromJSON.HighRiskPrefixes
+	}
+	p.vlogPathConfig.Fields = mergeVLogFields(p.vlogPathConfig.Fields, configFromJSON.Fields)
+	if len(configFromJSON.ContentTypeAllowlist) > 0 {
+		p.vlogPathConfig.ContentTypeAllowlist = normalizeContentTypes(configFromJSON.ContentTypeAllowlist)
+	}
+	if configFromJSON.SeedCacheWarmupDelay > 0 {
+		p.vlogPathConfig.SeedCacheWarmupDelay = configFromJSON.SeedCacheWarmupDelay
+	}
+	if len(configFromJSON.ExtraQueryFilters) > 0 {
+		p.vlogPathConfig.ExtraQueryFilters = configFromJSON.ExtraQueryFilters
+	}
+
+	if err := p.resolveSecureConfigValues(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *VLogPathPlugin) resolveSecureConfigValues() error {
+	// Credentials and endpoints may be plain values or secure-value references
+	// understood by the shared config package.
+	logServerPath := strings.TrimSpace(p.vlogPathConfig.LogServerPath)
+	if logServerPath != "" {
+		resolved, err := config.GetSecureValue(logServerPath)
+		if err != nil {
+			return fmt.Errorf("resolve VLog logServerPath: %w", err)
+		}
+
+		p.vlogPathConfig.LogServerPath = strings.TrimSpace(resolved)
+	}
+
+	p.vlogPathConfig.Username = p.resolveOptionalSecureValue("username", p.vlogPathConfig.Username)
+	p.vlogPathConfig.Password = p.resolveOptionalSecureValue("password", p.vlogPathConfig.Password)
+
+	return nil
+}
+
+func (p *VLogPathPlugin) resolveOptionalSecureValue(field, value string) string {
+	// Optional credentials resolve best-effort so an invalid optional secret does
+	// not block deployments that rely on anonymous log access.
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+
+	resolved, err := config.GetSecureValue(trimmed)
+	if err != nil {
+		p.log.Warn("Failed to resolve optional VLog secure config value", logger.Fields{
+			"field": field,
+			"error": err.Error(),
+		})
+		return trimmed
+	}
+
+	return strings.TrimSpace(resolved)
+}
+
+func (p *VLogPathPlugin) startTicker(ctx context.Context) {
+	// Give the informer a short head start so the first scan can use an initial
+	// cache of Ingress seed paths.
+	if p.vlogPathConfig.SeedCacheWarmupDelay > 0 {
+		select {
+		case <-time.After(time.Duration(p.vlogPathConfig.SeedCacheWarmupDelay) * time.Second):
+		case <-ctx.Done():
+			return
+		case <-p.stopChan:
+			return
+		}
+	}
+
+	p.runOnce(ctx)
+
+	ticker := time.NewTicker(time.Duration(p.vlogPathConfig.IntervalHour) * time.Hour)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			p.runOnce(ctx)
+		case <-ctx.Done():
+			return
+		case <-p.stopChan:
+			return
+		}
+	}
+}
+
+func (p *VLogPathPlugin) runOnce(ctx context.Context) {
+	// Each run queries logs by host and time bucket, then publishes only ranked
+	// child paths that are backed by current Ingress seed paths.
+	if p.client == nil || p.eventBus == nil || p.seedCache == nil {
+		return
+	}
+
+	if p.vlogPathConfig.LogServerPath == "" {
+		p.log.Warn("VLog server path is empty, skip VLog path discovery")
+		return
+	}
+
+	groups := p.seedCache.Groups()
+	if len(groups) == 0 {
+		p.log.Debug("Seed path cache is empty")
+		return
+	}
+
+	runCtx := ctx
+	cancel := func() {}
+	if p.vlogPathConfig.RunTimeoutSecond > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, time.Duration(p.vlogPathConfig.RunTimeoutSecond)*time.Second)
+	}
+	defer cancel()
+
+	now := time.Now()
+	windowStart := now.Add(-time.Duration(p.vlogPathConfig.LookbackHour) * time.Hour)
+	bucketDuration := time.Duration(p.vlogPathConfig.BucketHour) * time.Hour
+
+	if p.vlogPathConfig.MaxGroupsPerRun > 0 && len(groups) > p.vlogPathConfig.MaxGroupsPerRun {
+		p.log.Warn("VLog path discovery group count exceeds per-run limit", logger.Fields{
+			"seed_groups":        len(groups),
+			"max_groups_per_run": p.vlogPathConfig.MaxGroupsPerRun,
+		})
+		groups = groups[:p.vlogPathConfig.MaxGroupsPerRun]
+	}
+
+	totalPublished := p.processGroups(runCtx, groups, windowStart, now, bucketDuration)
+
+	p.log.Info("VLog path discovery run completed", logger.Fields{
+		"seed_groups":     len(groups),
+		"published_paths": totalPublished,
+	})
+}
+
+func (p *VLogPathPlugin) processGroups(
+	ctx context.Context,
+	groups []SeedPathGroup,
+	windowStart time.Time,
+	now time.Time,
+	bucketDuration time.Duration,
+) int {
+	concurrency := p.vlogPathConfig.QueryConcurrency
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	if concurrency > len(groups) && len(groups) > 0 {
+		concurrency = len(groups)
+	}
+
+	groupCh := make(chan SeedPathGroup)
+	publishedCh := make(chan int, len(groups))
+	var wg sync.WaitGroup
+
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for group := range groupCh {
+				publishedCh <- p.processGroup(ctx, group, windowStart, now, bucketDuration)
+			}
+		}()
+	}
+
+	go func() {
+		defer close(groupCh)
+		for _, group := range groups {
+			select {
+			case <-ctx.Done():
+				return
+			case groupCh <- group:
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(publishedCh)
+
+	totalPublished := 0
+	for count := range publishedCh {
+		totalPublished += count
+	}
+
+	return totalPublished
+}
+
+func (p *VLogPathPlugin) processGroup(
+	ctx context.Context,
+	group SeedPathGroup,
+	windowStart time.Time,
+	now time.Time,
+	bucketDuration time.Duration,
+) int {
+	candidates := make(map[string]*CandidatePath)
+	// Bucketed queries keep individual VLog requests bounded while still
+	// covering the full lookback window.
+	for start := windowStart; start.Before(now); start = start.Add(bucketDuration) {
+		select {
+		case <-ctx.Done():
+			p.log.Warn("VLog path discovery group processing stopped by context", logger.Fields{
+				"host":      group.Host,
+				"namespace": group.Namespace,
+				"error":     ctx.Err().Error(),
+			})
+			return 0
+		default:
+		}
+
+		end := start.Add(bucketDuration)
+		if end.After(now) {
+			end = now
+		}
+
+		entries, err := p.client.Query(
+			ctx,
+			group.Host,
+			start,
+			end,
+			p.vlogPathConfig.QueryLimitPerBucket,
+		)
+		if err != nil {
+			p.log.Error("Failed to query VLog", logger.Fields{
+				"host":      group.Host,
+				"namespace": group.Namespace,
+				"start":     start.Format(time.RFC3339),
+				"end":       end.Format(time.RFC3339),
+				"error":     err.Error(),
+			})
+			continue
+		}
+
+		p.collectCandidates(group, entries, candidates)
+	}
+
+	ranked := RankCandidates(
+		mapCandidates(candidates),
+		p.vlogPathConfig.TopNPerHost,
+		p.vlogPathConfig.HighRiskPrefixes,
+	)
+	for _, candidate := range ranked {
+		p.publishCandidate(candidate)
+	}
+
+	return len(ranked)
+}
+
+func (p *VLogPathPlugin) collectCandidates(
+	group SeedPathGroup,
+	entries []VLogEntry,
+	candidates map[string]*CandidatePath,
+) {
+	for _, entry := range entries {
+		// Keep candidates scoped to the host group built from Kubernetes Ingress
+		// state; this prevents cross-host log noise from creating discoveries.
+		if entry.Host != "" && !strings.EqualFold(entry.Host, group.Host) {
+			continue
+		}
+
+		if !isPageRequest(entry, p.vlogPathConfig.ContentTypeAllowlist) {
+			continue
+		}
+
+		normalizedPath, ok := NormalizePath(entry.Path)
+		if !ok {
+			continue
+		}
+
+		seed, ok := group.Match(normalizedPath)
+		if !ok {
+			continue
+		}
+
+		key := fmt.Sprintf("%s\x00%s\x00%s", seed.Namespace, seed.Host, normalizedPath)
+		candidate, exists := candidates[key]
+		if !exists {
+			candidate = &CandidatePath{
+				Seed: seed,
+				Path: normalizedPath,
+			}
+			candidates[key] = candidate
+		}
+
+		candidate.Count++
+		if entry.Time.After(candidate.LatestAccessTime) {
+			candidate.LatestAccessTime = entry.Time
+		}
+	}
+}
+
+func (p *VLogPathPlugin) publishCandidate(candidate CandidatePath) {
+	// The emitted payload uses the same DiscoveryInfo model as informer-based
+	// discovery plugins, allowing downstream detectors to consume it unchanged.
+	info := models.DiscoveryInfo{
+		DiscoveryName: candidate.Seed.DiscoveryName,
+		Name:          candidate.Seed.IngressName,
+		Namespace:     candidate.Seed.Namespace,
+		Host:          candidate.Seed.Host,
+		Path:          []string{candidate.Path},
+		ServiceName:   candidate.Seed.ServiceName,
+		HasActivePods: candidate.Seed.HasActivePods,
+		PodCount:      candidate.Seed.PodCount,
+	}
+
+	p.eventBus.Publish(constants.DiscoveryTopic, eventbus.Event{
+		Payload: info,
+	})
+
+	p.log.Debug("Published VLog discovered path", logger.Fields{
+		"namespace": info.Namespace,
+		"name":      info.Name,
+		"host":      info.Host,
+		"path":      info.Path,
+		"count":     candidate.Count,
+	})
+}
+
+func mapCandidates(candidates map[string]*CandidatePath) []CandidatePath {
+	// Pre-sort for deterministic ordering before applying the priority ranking.
+	items := make([]CandidatePath, 0, len(candidates))
+	for _, candidate := range candidates {
+		items = append(items, *candidate)
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Path < items[j].Path
+	})
+
+	return items
+}
+
+func isPageRequest(entry VLogEntry, allowlist []string) bool {
+	// Discovery focuses on successful page navigations so API calls and static
+	// assets do not flood the candidate list.
+	if entry.Method != "" && entry.Method != "GET" {
+		return false
+	}
+
+	if entry.StatusCode > 0 && (entry.StatusCode < 200 || entry.StatusCode >= 400) {
+		return false
+	}
+
+	return isAllowedContentType(entry.ResponseContentType, allowlist)
+}

--- a/complik/plugins/discovery/vlogpath/plugin.go
+++ b/complik/plugins/discovery/vlogpath/plugin.go
@@ -396,11 +396,14 @@ func (p *VLogPathPlugin) processGroups(
 	var wg sync.WaitGroup
 
 	for range concurrency {
-		wg.Go(func() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
 			for group := range groupCh {
 				publishedCh <- p.processGroup(ctx, group, windowStart, now, bucketDuration)
 			}
-		})
+		}()
 	}
 
 	go func() {

--- a/complik/plugins/discovery/vlogpath/plugin.go
+++ b/complik/plugins/discovery/vlogpath/plugin.go
@@ -14,12 +14,15 @@
 
 // Package vlogpath provides a discovery plugin that finds real HTML sub-paths
 // from gateway access logs and publishes them as discovery events.
+//
+//nolint:wsl_v5 // Plugin orchestration keeps related config and Kubernetes branches compact.
 package vlogpath
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 	"sync"
@@ -93,19 +96,26 @@ func (p *VLogPathPlugin) getDefaultVLogPathConfig() VLogPathConfig {
 	// Defaults favor conservative discovery: HTML pages only, a one-day
 	// lookback window, and higher priority for paths that commonly expose risk.
 	return VLogPathConfig{
-		App:                  "higress",
-		IntervalHour:         6,
-		LookbackHour:         24,
-		BucketHour:           1,
-		TopNPerHost:          50,
-		QueryLimitPerBucket:  50,
-		MaxGroupsPerRun:      500,
-		QueryConcurrency:     3,
-		RunTimeoutSecond:     900,
-		HTTPTimeoutSecond:    30,
-		ResyncTimeSecond:     30,
-		NamespacePrefix:      "ns-",
-		HighRiskPrefixes:     []string{"/admin", "/login", "/pay", "/payment", "/promo", "/activity"},
+		App:                 "higress",
+		IntervalHour:        6,
+		LookbackHour:        24,
+		BucketHour:          1,
+		TopNPerHost:         50,
+		QueryLimitPerBucket: 50,
+		MaxGroupsPerRun:     500,
+		QueryConcurrency:    3,
+		RunTimeoutSecond:    900,
+		HTTPTimeoutSecond:   30,
+		ResyncTimeSecond:    30,
+		NamespacePrefix:     "ns-",
+		HighRiskPrefixes: []string{
+			"/admin",
+			"/login",
+			"/pay",
+			"/payment",
+			"/promo",
+			"/activity",
+		},
 		Fields:               DefaultVLogFields(),
 		ContentTypeAllowlist: []string{"text/html", "application/xhtml+xml"},
 		SeedCacheWarmupDelay: 5,
@@ -231,7 +241,9 @@ func (p *VLogPathPlugin) loadConfig(setting string) error {
 	}
 	p.vlogPathConfig.Fields = mergeVLogFields(p.vlogPathConfig.Fields, configFromJSON.Fields)
 	if len(configFromJSON.ContentTypeAllowlist) > 0 {
-		p.vlogPathConfig.ContentTypeAllowlist = normalizeContentTypes(configFromJSON.ContentTypeAllowlist)
+		p.vlogPathConfig.ContentTypeAllowlist = normalizeContentTypes(
+			configFromJSON.ContentTypeAllowlist,
+		)
 	}
 	if configFromJSON.SeedCacheWarmupDelay > 0 {
 		p.vlogPathConfig.SeedCacheWarmupDelay = configFromJSON.SeedCacheWarmupDelay
@@ -337,7 +349,10 @@ func (p *VLogPathPlugin) runOnce(ctx context.Context) {
 	runCtx := ctx
 	cancel := func() {}
 	if p.vlogPathConfig.RunTimeoutSecond > 0 {
-		runCtx, cancel = context.WithTimeout(ctx, time.Duration(p.vlogPathConfig.RunTimeoutSecond)*time.Second)
+		runCtx, cancel = context.WithTimeout(
+			ctx,
+			time.Duration(p.vlogPathConfig.RunTimeoutSecond)*time.Second,
+		)
 	}
 	defer cancel()
 
@@ -381,13 +396,11 @@ func (p *VLogPathPlugin) processGroups(
 	var wg sync.WaitGroup
 
 	for range concurrency {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for group := range groupCh {
 				publishedCh <- p.processGroup(ctx, group, windowStart, now, bucketDuration)
 			}
-		}()
+		})
 	}
 
 	go func() {
@@ -559,7 +572,7 @@ func mapCandidates(candidates map[string]*CandidatePath) []CandidatePath {
 func isPageRequest(entry VLogEntry, allowlist []string) bool {
 	// Discovery focuses on successful page navigations so API calls and static
 	// assets do not flood the candidate list.
-	if entry.Method != "" && entry.Method != "GET" {
+	if entry.Method != "" && entry.Method != http.MethodGet {
 		return false
 	}
 

--- a/complik/plugins/discovery/vlogpath/vlog.go
+++ b/complik/plugins/discovery/vlogpath/vlog.go
@@ -202,7 +202,8 @@ func (c *VLogClient) buildQuery(host string, start, end time.Time, limit int) st
 
 	fmt.Fprintf(
 		&builder,
-		`_time:[%s,%s] `,
+		`%s:[%s,%s] `,
+		c.fields.Time,
 		start.UTC().Format(time.RFC3339),
 		end.UTC().Format(time.RFC3339),
 	)

--- a/complik/plugins/discovery/vlogpath/vlog.go
+++ b/complik/plugins/discovery/vlogpath/vlog.go
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:wsl_v5 // VLog parsing handles several compact schema branches.
 package vlogpath
 
 import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -143,7 +145,7 @@ func (c *VLogClient) Query(
 	// Query returns normalized entries only; filtering and ranking stay in the
 	// plugin layer where Ingress seed context is available.
 	if strings.TrimSpace(c.baseURL) == "" {
-		return nil, fmt.Errorf("VLog base URL is empty")
+		return nil, errors.New("VLog base URL is empty")
 	}
 
 	if limit <= 0 {
@@ -198,7 +200,12 @@ func (c *VLogClient) buildQuery(host string, start, end time.Time, limit int) st
 		fmt.Fprintf(&builder, `%s:="%s" `, key, escapeLogQLValue(fmt.Sprint(value)))
 	}
 
-	fmt.Fprintf(&builder, `_time:[%s,%s] `, start.UTC().Format(time.RFC3339), end.UTC().Format(time.RFC3339))
+	fmt.Fprintf(
+		&builder,
+		`_time:[%s,%s] `,
+		start.UTC().Format(time.RFC3339),
+		end.UTC().Format(time.RFC3339),
+	)
 	builder.WriteString(`| unpack_json `)
 	builder.WriteString(`| Drop _stream_id,_stream,job,node `)
 	fmt.Fprintf(&builder, `| limit %d`, limit)
@@ -287,12 +294,33 @@ func (c *VLogClient) parseRows(rows []map[string]any) []VLogEntry {
 	entries := make([]VLogEntry, 0, len(rows))
 	for _, row := range rows {
 		entry := VLogEntry{
-			Time:                readTime(row, c.fields.Time),
-			Host:                readString(row, c.fields.Host),
-			Path:                readFirstString(row, c.fields.Path, "request_path", "uri", "request_uri", "url_path"),
-			Method:              strings.ToUpper(readFirstString(row, c.fields.Method, "request_method", "http_method")),
-			StatusCode:          readInt(row, c.fields.StatusCode, "status", "statusCode", "response_code"),
-			ResponseContentType: readFirstString(row, c.fields.ResponseContentType, "content_type", "responseContentType", "resp_content_type"),
+			Time: readTime(row, c.fields.Time),
+			Host: readString(row, c.fields.Host),
+			Path: readFirstString(
+				row,
+				c.fields.Path,
+				"request_path",
+				"uri",
+				"request_uri",
+				"url_path",
+			),
+			Method: strings.ToUpper(
+				readFirstString(row, c.fields.Method, "request_method", "http_method"),
+			),
+			StatusCode: readInt(
+				row,
+				c.fields.StatusCode,
+				"status",
+				"statusCode",
+				"response_code",
+			),
+			ResponseContentType: readFirstString(
+				row,
+				c.fields.ResponseContentType,
+				"content_type",
+				"responseContentType",
+				"resp_content_type",
+			),
 		}
 
 		if entry.Path == "" {

--- a/complik/plugins/discovery/vlogpath/vlog.go
+++ b/complik/plugins/discovery/vlogpath/vlog.go
@@ -1,0 +1,413 @@
+// Copyright 2025 CompliK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vlogpath
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// VLogFields maps CompliK's expected values onto the field names present in a
+// specific VLog deployment.
+type VLogFields struct {
+	Time                string `json:"time"`
+	Host                string `json:"host"`
+	Path                string `json:"path"`
+	Method              string `json:"method"`
+	StatusCode          string `json:"statusCode"`
+	ResponseContentType string `json:"responseContentType"`
+}
+
+// DefaultVLogFields matches the log schema emitted by the default Higress VLog
+// pipeline.
+func DefaultVLogFields() VLogFields {
+	return VLogFields{
+		Time:                "_time",
+		Host:                "host",
+		Path:                "path",
+		Method:              "method",
+		StatusCode:          "status_code",
+		ResponseContentType: "response_content_type",
+	}
+}
+
+func mergeVLogFields(base, override VLogFields) VLogFields {
+	// Apply only explicit field-name overrides so partial config keeps the
+	// default schema for omitted values.
+	if override.Time != "" {
+		base.Time = override.Time
+	}
+	if override.Host != "" {
+		base.Host = override.Host
+	}
+	if override.Path != "" {
+		base.Path = override.Path
+	}
+	if override.Method != "" {
+		base.Method = override.Method
+	}
+	if override.StatusCode != "" {
+		base.StatusCode = override.StatusCode
+	}
+	if override.ResponseContentType != "" {
+		base.ResponseContentType = override.ResponseContentType
+	}
+
+	return base
+}
+
+// VLogEntry is the normalized subset of an access-log row needed for path
+// discovery.
+type VLogEntry struct {
+	Time                time.Time
+	Host                string
+	Path                string
+	Method              string
+	StatusCode          int
+	ResponseContentType string
+}
+
+// VLogClientConfig contains connection details and query shaping options for
+// a VLog server.
+type VLogClientConfig struct {
+	BaseURL             string
+	Username            string
+	Password            string
+	App                 string
+	Fields              VLogFields
+	HTTPTimeout         time.Duration
+	QueryLimitPerBucket int
+	ExtraQueryFilters   map[string]any
+}
+
+// VLogClient queries VLog's LogSQL endpoint and normalizes the response into
+// VLogEntry values.
+type VLogClient struct {
+	baseURL           string
+	username          string
+	password          string
+	app               string
+	fields            VLogFields
+	extraQueryFilters map[string]any
+	client            *http.Client
+}
+
+func NewVLogClient(config VLogClientConfig) *VLogClient {
+	// Always keep an HTTP timeout to prevent one slow log query from stalling a
+	// full discovery cycle.
+	timeout := config.HTTPTimeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
+	return &VLogClient{
+		baseURL:           strings.TrimRight(config.BaseURL, "/"),
+		username:          config.Username,
+		password:          config.Password,
+		app:               config.App,
+		fields:            mergeVLogFields(DefaultVLogFields(), config.Fields),
+		extraQueryFilters: config.ExtraQueryFilters,
+		client: &http.Client{
+			Timeout: timeout,
+		},
+	}
+}
+
+func (c *VLogClient) Query(
+	ctx context.Context,
+	host string,
+	start time.Time,
+	end time.Time,
+	limit int,
+) ([]VLogEntry, error) {
+	// Query returns normalized entries only; filtering and ranking stay in the
+	// plugin layer where Ingress seed context is available.
+	if strings.TrimSpace(c.baseURL) == "" {
+		return nil, fmt.Errorf("VLog base URL is empty")
+	}
+
+	if limit <= 0 {
+		limit = 50
+	}
+
+	query := c.buildQuery(host, start, end, limit)
+	reqURL := c.baseURL + "/select/logsql/query?query=" + url.QueryEscape(query)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create VLog query request: %w", err)
+	}
+
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send VLog query request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("VLog query returned HTTP %d", resp.StatusCode)
+	}
+
+	entries, err := c.parseResponse(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}
+
+func (c *VLogClient) buildQuery(host string, start, end time.Time, limit int) string {
+	// Build LogSQL with strict host and time predicates first, then unpack JSON
+	// log payloads for field extraction.
+	var builder strings.Builder
+
+	fmt.Fprintf(&builder, `%s:"%s" `, c.fields.Host, escapeLogQLValue(host))
+	if c.app != "" {
+		fmt.Fprintf(&builder, `app:="%s" `, escapeLogQLValue(c.app))
+	}
+
+	for key, value := range c.extraQueryFilters {
+		if strings.TrimSpace(key) == "" || value == nil {
+			continue
+		}
+
+		fmt.Fprintf(&builder, `%s:="%s" `, key, escapeLogQLValue(fmt.Sprint(value)))
+	}
+
+	fmt.Fprintf(&builder, `_time:[%s,%s] `, start.UTC().Format(time.RFC3339), end.UTC().Format(time.RFC3339))
+	builder.WriteString(`| unpack_json `)
+	builder.WriteString(`| Drop _stream_id,_stream,job,node `)
+	fmt.Fprintf(&builder, `| limit %d`, limit)
+
+	return builder.String()
+}
+
+func escapeLogQLValue(value string) string {
+	// Escape values embedded inside quoted LogSQL string literals.
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `"`, `\"`)
+	return value
+}
+
+func (c *VLogClient) parseResponse(reader io.Reader) ([]VLogEntry, error) {
+	// VLog deployments may return a JSON envelope, a raw array, or JSON Lines;
+	// support all three formats to keep the plugin portable.
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read VLog response: %w", err)
+	}
+
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return []VLogEntry{}, nil
+	}
+
+	var raw any
+	if err := json.Unmarshal(data, &raw); err == nil {
+		if rows := findRows(raw); len(rows) > 0 {
+			return c.parseRows(rows), nil
+		}
+	}
+
+	return c.parseJSONLines(data), nil
+}
+
+func findRows(raw any) []map[string]any {
+	// Walk common envelope keys until a slice of row objects is found.
+	switch value := raw.(type) {
+	case []any:
+		rows := make([]map[string]any, 0, len(value))
+		for _, item := range value {
+			if row, ok := item.(map[string]any); ok {
+				rows = append(rows, row)
+			}
+		}
+		return rows
+	case map[string]any:
+		for _, key := range []string{"data", "values", "result", "hits", "logs"} {
+			if rows := findRows(value[key]); len(rows) > 0 {
+				return rows
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *VLogClient) parseJSONLines(data []byte) []VLogEntry {
+	// Some log APIs stream one JSON object per line, so malformed lines are
+	// skipped while valid rows still contribute candidates.
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	rows := make([]map[string]any, 0)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var row map[string]any
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			continue
+		}
+
+		rows = append(rows, row)
+	}
+
+	return c.parseRows(rows)
+}
+
+func (c *VLogClient) parseRows(rows []map[string]any) []VLogEntry {
+	// Use configured field names first and then known aliases from common proxy
+	// access-log schemas.
+	entries := make([]VLogEntry, 0, len(rows))
+	for _, row := range rows {
+		entry := VLogEntry{
+			Time:                readTime(row, c.fields.Time),
+			Host:                readString(row, c.fields.Host),
+			Path:                readFirstString(row, c.fields.Path, "request_path", "uri", "request_uri", "url_path"),
+			Method:              strings.ToUpper(readFirstString(row, c.fields.Method, "request_method", "http_method")),
+			StatusCode:          readInt(row, c.fields.StatusCode, "status", "statusCode", "response_code"),
+			ResponseContentType: readFirstString(row, c.fields.ResponseContentType, "content_type", "responseContentType", "resp_content_type"),
+		}
+
+		if entry.Path == "" {
+			continue
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
+func readFirstString(row map[string]any, keys ...string) string {
+	// Return the first populated value across a field name and its aliases.
+	for _, key := range keys {
+		value := readString(row, key)
+		if value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func readString(row map[string]any, key string) string {
+	// Convert scalar JSON values into strings because log backends often vary
+	// field types between numeric and textual representations.
+	if strings.TrimSpace(key) == "" {
+		return ""
+	}
+
+	value, exists := row[key]
+	if !exists {
+		return ""
+	}
+
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case fmt.Stringer:
+		return strings.TrimSpace(typed.String())
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(typed)
+	case int64:
+		return strconv.FormatInt(typed, 10)
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
+}
+
+func readInt(row map[string]any, keys ...string) int {
+	// Treat an unreadable status as zero so callers can decide how strict their
+	// filtering should be.
+	for _, key := range keys {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+
+		value, exists := row[key]
+		if !exists {
+			continue
+		}
+
+		switch typed := value.(type) {
+		case int:
+			return typed
+		case int64:
+			return int(typed)
+		case float64:
+			return int(typed)
+		case json.Number:
+			if parsed, err := typed.Int64(); err == nil {
+				return int(parsed)
+			}
+		case string:
+			parsed, err := strconv.Atoi(strings.TrimSpace(typed))
+			if err == nil {
+				return parsed
+			}
+		}
+	}
+
+	return 0
+}
+
+func readTime(row map[string]any, key string) time.Time {
+	// Accept common timestamp layouts and Unix seconds/milliseconds from log
+	// backends; fall back to now so ranking can still proceed.
+	value := readString(row, key)
+	if value == "" {
+		return time.Now()
+	}
+
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		time.DateTime,
+		"2006-01-02T15:04:05.000Z",
+	}
+	for _, layout := range layouts {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed
+		}
+	}
+
+	if unixSeconds, err := strconv.ParseInt(value, 10, 64); err == nil {
+		if unixSeconds > 1_000_000_000_000 {
+			return time.UnixMilli(unixSeconds)
+		}
+
+		return time.Unix(unixSeconds, 0)
+	}
+
+	return time.Now()
+}

--- a/complik/plugins/handle/lark/aggregator.go
+++ b/complik/plugins/handle/lark/aggregator.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:wsl_v5 // Aggregation code keeps related state transitions compact.
 package lark
 
 import (
@@ -193,7 +194,12 @@ func aggregateKey(namespace, host string) string {
 	return strings.TrimSpace(namespace) + "\x00" + strings.ToLower(strings.TrimSpace(host))
 }
 
-func mergeDetectorInfo(alert *AggregatedAlert, result *models.DetectorInfo, now time.Time, maxPaths int) {
+func mergeDetectorInfo(
+	alert *AggregatedAlert,
+	result *models.DetectorInfo,
+	now time.Time,
+	maxPaths int,
+) {
 	if strings.TrimSpace(alert.Region) == "" {
 		alert.Region = strings.TrimSpace(result.Region)
 	}

--- a/complik/plugins/handle/lark/aggregator.go
+++ b/complik/plugins/handle/lark/aggregator.go
@@ -1,0 +1,327 @@
+// Copyright 2025 CompliK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lark
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bearslyricattack/CompliK/complik/pkg/logger"
+	"github.com/bearslyricattack/CompliK/complik/pkg/models"
+)
+
+const (
+	defaultAggregationWindow     = 5 * time.Minute
+	defaultMaxAggregationBuckets = 1000
+	defaultMaxPathsPerBucket     = 50
+)
+
+type NotificationAggregator struct {
+	mu                sync.Mutex
+	window            time.Duration
+	maxBuckets        int
+	maxPathsPerBucket int
+	notifier          *Notifier
+	log               logger.Logger
+	buckets           map[string]*notificationBucket
+	stopped           bool
+}
+
+type notificationBucket struct {
+	key       string
+	alert     AggregatedAlert
+	timer     *time.Timer
+	createdAt time.Time
+}
+
+func NewNotificationAggregator(
+	window time.Duration,
+	maxBuckets int,
+	maxPathsPerBucket int,
+	notifier *Notifier,
+	log logger.Logger,
+) *NotificationAggregator {
+	if window <= 0 {
+		window = defaultAggregationWindow
+	}
+	if maxBuckets <= 0 {
+		maxBuckets = defaultMaxAggregationBuckets
+	}
+	if maxPathsPerBucket <= 0 {
+		maxPathsPerBucket = defaultMaxPathsPerBucket
+	}
+
+	return &NotificationAggregator{
+		window:            window,
+		maxBuckets:        maxBuckets,
+		maxPathsPerBucket: maxPathsPerBucket,
+		notifier:          notifier,
+		log:               log,
+		buckets:           make(map[string]*notificationBucket),
+	}
+}
+
+func (a *NotificationAggregator) Add(result *models.DetectorInfo) {
+	if !shouldAggregate(result) {
+		return
+	}
+
+	now := time.Now()
+	key := aggregateKey(result.Namespace, result.Host)
+
+	a.mu.Lock()
+	if a.stopped {
+		a.mu.Unlock()
+		return
+	}
+
+	bucket, exists := a.buckets[key]
+	if !exists {
+		if len(a.buckets) >= a.maxBuckets {
+			a.mu.Unlock()
+			a.log.Warn("Aggregated notification bucket limit reached", logger.Fields{
+				"namespace":   result.Namespace,
+				"host":        result.Host,
+				"max_buckets": a.maxBuckets,
+			})
+			return
+		}
+
+		bucket = &notificationBucket{
+			key: key,
+			alert: AggregatedAlert{
+				Region:      result.Region,
+				Namespace:   result.Namespace,
+				Host:        result.Host,
+				Resource:    result.Name,
+				FirstSeenAt: now,
+				LastSeenAt:  now,
+				Paths:       make(map[string]*AggregatedPath),
+			},
+			createdAt: now,
+		}
+		a.buckets[key] = bucket
+		bucket.timer = time.AfterFunc(a.window, func() {
+			a.flush(key)
+		})
+	}
+
+	mergeDetectorInfo(&bucket.alert, result, now, a.maxPathsPerBucket)
+	a.mu.Unlock()
+}
+
+func (a *NotificationAggregator) Stop() {
+	a.mu.Lock()
+	if a.stopped {
+		a.mu.Unlock()
+		return
+	}
+	a.stopped = true
+
+	keys := make([]string, 0, len(a.buckets))
+	for key := range a.buckets {
+		keys = append(keys, key)
+	}
+	a.mu.Unlock()
+
+	for _, key := range keys {
+		a.flush(key)
+	}
+}
+
+func (a *NotificationAggregator) flush(key string) {
+	a.mu.Lock()
+	bucket, exists := a.buckets[key]
+	if !exists {
+		a.mu.Unlock()
+		return
+	}
+
+	delete(a.buckets, key)
+	if bucket.timer != nil {
+		bucket.timer.Stop()
+	}
+
+	alert := bucket.alert.snapshot()
+	a.mu.Unlock()
+
+	if len(alert.Paths) == 0 {
+		return
+	}
+
+	if err := a.notifier.SendAggregatedNotification(alert); err != nil {
+		a.log.Error("Failed to send aggregated notification", logger.Fields{
+			"error":      err.Error(),
+			"namespace":  alert.Namespace,
+			"host":       alert.Host,
+			"path_count": len(alert.Paths),
+		})
+
+		return
+	}
+
+	a.log.Info("Aggregated notification sent", logger.Fields{
+		"namespace":  alert.Namespace,
+		"host":       alert.Host,
+		"path_count": len(alert.Paths),
+	})
+}
+
+func shouldAggregate(result *models.DetectorInfo) bool {
+	return result != nil &&
+		result.IsIllegal &&
+		strings.TrimSpace(result.Namespace) != "" &&
+		strings.TrimSpace(result.Host) != ""
+}
+
+func aggregateKey(namespace, host string) string {
+	return strings.TrimSpace(namespace) + "\x00" + strings.ToLower(strings.TrimSpace(host))
+}
+
+func mergeDetectorInfo(alert *AggregatedAlert, result *models.DetectorInfo, now time.Time, maxPaths int) {
+	if strings.TrimSpace(alert.Region) == "" {
+		alert.Region = strings.TrimSpace(result.Region)
+	}
+	if strings.TrimSpace(alert.Resource) == "" {
+		alert.Resource = strings.TrimSpace(result.Name)
+	}
+
+	if alert.FirstSeenAt.IsZero() || now.Before(alert.FirstSeenAt) {
+		alert.FirstSeenAt = now
+	}
+	if now.After(alert.LastSeenAt) {
+		alert.LastSeenAt = now
+	}
+
+	if alert.Paths == nil {
+		alert.Paths = make(map[string]*AggregatedPath)
+	}
+
+	paths := normalizedResultPaths(result)
+	for _, path := range paths {
+		item := alert.Paths[path]
+		if item == nil {
+			if maxPaths > 0 && len(alert.Paths) >= maxPaths {
+				alert.OmittedPathCount++
+				continue
+			}
+
+			item = &AggregatedPath{
+				Path:         path,
+				URL:          urlForPath(result, path),
+				Detectors:    make(map[string]struct{}),
+				Keywords:     make(map[string]struct{}),
+				Devices:      make(map[string]struct{}),
+				Descriptions: make(map[string]struct{}),
+				Explanations: make(map[string]struct{}),
+			}
+			alert.Paths[path] = item
+		}
+
+		if strings.TrimSpace(item.URL) == "" {
+			item.URL = urlForPath(result, path)
+		}
+
+		addSetValue(item.Detectors, result.DetectorName)
+		addSetValue(item.Devices, result.DeviceProfile)
+		addSetValue(item.Descriptions, result.Description)
+		addSetValue(item.Explanations, result.Explanation)
+		for _, keyword := range result.Keywords {
+			addSetValue(item.Keywords, keyword)
+		}
+	}
+}
+
+func normalizedResultPaths(result *models.DetectorInfo) []string {
+	if result == nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	paths := make([]string, 0, len(result.Path))
+	for _, rawPath := range result.Path {
+		path := normalizeAlertPath(rawPath)
+		if _, exists := seen[path]; exists {
+			continue
+		}
+
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+
+	if len(paths) == 0 {
+		paths = append(paths, pathFromURL(result.URL))
+	}
+
+	sort.Strings(paths)
+
+	return paths
+}
+
+func normalizeAlertPath(value string) string {
+	path := strings.TrimSpace(value)
+	if path == "" {
+		return "/"
+	}
+
+	if parsed, err := url.Parse(path); err == nil && parsed.Path != "" {
+		path = parsed.Path
+	}
+
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	return path
+}
+
+func pathFromURL(rawURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err == nil && strings.TrimSpace(parsed.Path) != "" {
+		return normalizeAlertPath(parsed.Path)
+	}
+
+	return "/"
+}
+
+func urlForPath(result *models.DetectorInfo, path string) string {
+	rawURL := strings.TrimSpace(result.URL)
+	if rawURL == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return rawURL
+	}
+
+	parsed.Path = normalizeAlertPath(path)
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+
+	return parsed.String()
+}
+
+func addSetValue(set map[string]struct{}, value string) {
+	item := strings.TrimSpace(value)
+	if item == "" {
+		return
+	}
+
+	set[item] = struct{}{}
+}

--- a/complik/plugins/handle/lark/aggregator_test.go
+++ b/complik/plugins/handle/lark/aggregator_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:testpackage,wsl_v5 // Tests exercise unexported aggregation helpers.
 package lark
 
 import (
@@ -33,7 +34,7 @@ func TestMergeDetectorInfoAggregatesSitePaths(t *testing.T) {
 		Host:      "example.com",
 		Paths:     map[string]*AggregatedPath{},
 	}
-	now := time.Date(2026, 6, 16, 14, 3, 0, 0, time.Local)
+	now := time.Date(2026, time.June, 16, 14, 3, 0, 0, time.Local)
 
 	mergeDetectorInfo(&alert, &models.DetectorInfo{
 		DetectorName:  "Safety",
@@ -110,7 +111,13 @@ func TestNotificationAggregatorSendsOneAggregatedMessage(t *testing.T) {
 
 	logger.Init()
 	notifier := NewNotifier(server.URL, "53")
-	aggregator := NewNotificationAggregator(20*time.Millisecond, 1000, 50, notifier, logger.GetLogger())
+	aggregator := NewNotificationAggregator(
+		20*time.Millisecond,
+		1000,
+		50,
+		notifier,
+		logger.GetLogger(),
+	)
 
 	aggregator.Add(&models.DetectorInfo{
 		DetectorName:  "Safety",
@@ -167,7 +174,7 @@ func TestAggregatorLimitsPathsPerBucket(t *testing.T) {
 		Host:      "example.com",
 		Paths:     map[string]*AggregatedPath{},
 	}
-	now := time.Date(2026, 6, 16, 14, 3, 0, 0, time.Local)
+	now := time.Date(2026, time.June, 16, 14, 3, 0, 0, time.Local)
 
 	mergeDetectorInfo(&alert, &models.DetectorInfo{
 		DetectorName: "Safety",
@@ -193,8 +200,8 @@ func TestAggregatedCardShowsOmittedPathCount(t *testing.T) {
 		Resource:         "complik-demo-ing",
 		Namespace:        "ns-demo",
 		Host:             "example.com",
-		FirstSeenAt:      time.Date(2026, 6, 17, 7, 52, 38, 0, time.Local),
-		LastSeenAt:       time.Date(2026, 6, 17, 7, 57, 38, 0, time.Local),
+		FirstSeenAt:      time.Date(2026, time.June, 17, 7, 52, 38, 0, time.Local),
+		LastSeenAt:       time.Date(2026, time.June, 17, 7, 57, 38, 0, time.Local),
 		OmittedPathCount: 3,
 		Paths: map[string]*AggregatedPath{
 			"/gambling": {
@@ -219,7 +226,7 @@ func TestAggregatedCardShowsOmittedPathCount(t *testing.T) {
 }
 
 func TestAggregatedCardUsesOriginalMarkdownFormat(t *testing.T) {
-	firstSeen := time.Date(2026, 6, 17, 7, 52, 38, 0, time.Local)
+	firstSeen := time.Date(2026, time.June, 17, 7, 52, 38, 0, time.Local)
 	alert := AggregatedAlert{
 		Region:      "53",
 		Resource:    "complik-demo-ing",

--- a/complik/plugins/handle/lark/aggregator_test.go
+++ b/complik/plugins/handle/lark/aggregator_test.go
@@ -1,0 +1,285 @@
+// Copyright 2025 CompliK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lark
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bearslyricattack/CompliK/complik/pkg/logger"
+	"github.com/bearslyricattack/CompliK/complik/pkg/models"
+)
+
+func TestMergeDetectorInfoAggregatesSitePaths(t *testing.T) {
+	alert := AggregatedAlert{
+		Namespace: "ns-demo",
+		Host:      "example.com",
+		Paths:     map[string]*AggregatedPath{},
+	}
+	now := time.Date(2026, 6, 16, 14, 3, 0, 0, time.Local)
+
+	mergeDetectorInfo(&alert, &models.DetectorInfo{
+		DetectorName:  "Safety",
+		Name:          "demo-ingress",
+		Namespace:     "ns-demo",
+		Host:          "example.com",
+		Path:          []string{"/activity/a"},
+		URL:           "http://example.com/activity/a",
+		DeviceProfile: "desktop",
+		Description:   "活动页面包含博彩充值入口",
+		Keywords:      []string{"xxx"},
+		IsIllegal:     true,
+		Explanation:   "页面出现投注与充值提现相关文案",
+	}, now, 50)
+	mergeDetectorInfo(&alert, &models.DetectorInfo{
+		DetectorName:  "Custom",
+		Name:          "demo-ingress",
+		Namespace:     "ns-demo",
+		Host:          "example.com",
+		Path:          []string{"/activity/a", "/admin/promo"},
+		URL:           "http://example.com/activity/a",
+		DeviceProfile: "mobile",
+		Description:   "页面包含推广活动入口",
+		Keywords:      []string{"xxx", "yyy"},
+		IsIllegal:     true,
+		Explanation:   "命中自定义博彩关键词规则",
+	}, now.Add(time.Minute), 50)
+
+	paths := alert.SortedPaths()
+	if len(paths) != 2 {
+		t.Fatalf("path count = %d, want 2", len(paths))
+	}
+	if paths[0].Path != "/activity/a" {
+		t.Fatalf("first path = %q, want /activity/a", paths[0].Path)
+	}
+	if got := strings.Join(paths[0].Detectors, ","); got != "Custom,Safety" {
+		t.Fatalf("detectors = %q, want Custom,Safety", got)
+	}
+	if got := strings.Join(paths[0].Devices, ","); got != "desktop,mobile" {
+		t.Fatalf("devices = %q, want desktop,mobile", got)
+	}
+	if got := strings.Join(paths[0].Keywords, ","); got != "xxx,yyy" {
+		t.Fatalf("keywords = %q, want xxx,yyy", got)
+	}
+	if got := strings.Join(paths[0].Descriptions, ","); got != "活动页面包含博彩充值入口,页面包含推广活动入口" {
+		t.Fatalf("descriptions = %q, want merged descriptions", got)
+	}
+	if got := strings.Join(paths[0].Explanations, ","); got != "命中自定义博彩关键词规则,页面出现投注与充值提现相关文案" {
+		t.Fatalf("explanations = %q, want merged explanations", got)
+	}
+	if paths[1].Path != "/admin/promo" {
+		t.Fatalf("second path = %q, want /admin/promo", paths[1].Path)
+	}
+}
+
+func TestNotificationAggregatorSendsOneAggregatedMessage(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		messages []LarkMessage
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var message LarkMessage
+		if err := json.NewDecoder(r.Body).Decode(&message); err != nil {
+			t.Errorf("decode message: %v", err)
+		}
+
+		mu.Lock()
+		messages = append(messages, message)
+		mu.Unlock()
+
+		_, _ = w.Write([]byte(`{"code":0,"msg":"ok"}`))
+	}))
+	defer server.Close()
+
+	logger.Init()
+	notifier := NewNotifier(server.URL, "53")
+	aggregator := NewNotificationAggregator(20*time.Millisecond, 1000, 50, notifier, logger.GetLogger())
+
+	aggregator.Add(&models.DetectorInfo{
+		DetectorName:  "Safety",
+		Name:          "demo-ingress",
+		Namespace:     "ns-demo",
+		Region:        "53",
+		Host:          "example.com",
+		Path:          []string{"/yellow"},
+		URL:           "http://example.com/yellow",
+		DeviceProfile: "desktop",
+		Description:   "黄色内容落地页",
+		Keywords:      []string{"adult"},
+		IsIllegal:     true,
+		Explanation:   "页面包含成人内容导流信息",
+	})
+	aggregator.Add(&models.DetectorInfo{
+		DetectorName:  "Safety",
+		Name:          "demo-ingress",
+		Namespace:     "ns-demo",
+		Region:        "53",
+		Host:          "example.com",
+		Path:          []string{"/gambling"},
+		URL:           "http://example.com/gambling",
+		DeviceProfile: "mobile",
+		Description:   "博彩活动落地页",
+		Keywords:      []string{"casino"},
+		IsIllegal:     true,
+		Explanation:   "页面含赌场和下注相关文案",
+	})
+
+	time.Sleep(80 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(messages))
+	}
+
+	data, err := json.Marshal(messages[0])
+	if err != nil {
+		t.Fatalf("marshal message: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{"/yellow", "/gambling", "adult", "casino", "黄色内容落地页", "博彩活动落地页", "页面包含成人内容导流信息", "页面含赌场和下注相关文案", "发现违规路径:** 2 个"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("message body missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestAggregatorLimitsPathsPerBucket(t *testing.T) {
+	alert := AggregatedAlert{
+		Namespace: "ns-demo",
+		Host:      "example.com",
+		Paths:     map[string]*AggregatedPath{},
+	}
+	now := time.Date(2026, 6, 16, 14, 3, 0, 0, time.Local)
+
+	mergeDetectorInfo(&alert, &models.DetectorInfo{
+		DetectorName: "Safety",
+		Namespace:    "ns-demo",
+		Host:         "example.com",
+		Path:         []string{"/a", "/b", "/c"},
+		URL:          "http://example.com/a",
+		Keywords:     []string{"casino"},
+		IsIllegal:    true,
+	}, now, 2)
+
+	if len(alert.Paths) != 2 {
+		t.Fatalf("path count = %d, want 2", len(alert.Paths))
+	}
+	if alert.OmittedPathCount != 1 {
+		t.Fatalf("omitted path count = %d, want 1", alert.OmittedPathCount)
+	}
+}
+
+func TestAggregatedCardShowsOmittedPathCount(t *testing.T) {
+	alert := AggregatedAlert{
+		Region:           "53",
+		Resource:         "complik-demo-ing",
+		Namespace:        "ns-demo",
+		Host:             "example.com",
+		FirstSeenAt:      time.Date(2026, 6, 17, 7, 52, 38, 0, time.Local),
+		LastSeenAt:       time.Date(2026, 6, 17, 7, 57, 38, 0, time.Local),
+		OmittedPathCount: 3,
+		Paths: map[string]*AggregatedPath{
+			"/gambling": {
+				Path:      "/gambling",
+				URL:       "http://example.com/gambling",
+				Detectors: map[string]struct{}{"Safety": {}},
+				Keywords:  map[string]struct{}{"casino": {}},
+			},
+		},
+	}
+
+	card := NewNotifier("http://example.com/webhook", "53").buildAggregatedAlertMessage(alert)
+	data, err := json.Marshal(card)
+	if err != nil {
+		t.Fatalf("marshal card: %v", err)
+	}
+
+	body := string(data)
+	if !strings.Contains(body, "另有 3 条违规路径已省略") {
+		t.Fatalf("card body missing omitted path count: %s", body)
+	}
+}
+
+func TestAggregatedCardUsesOriginalMarkdownFormat(t *testing.T) {
+	firstSeen := time.Date(2026, 6, 17, 7, 52, 38, 0, time.Local)
+	alert := AggregatedAlert{
+		Region:      "53",
+		Resource:    "complik-demo-ing",
+		Namespace:   "ns-demo",
+		Host:        "example.com",
+		FirstSeenAt: firstSeen,
+		LastSeenAt:  firstSeen.Add(5 * time.Minute),
+		Paths: map[string]*AggregatedPath{
+			"/yellow": {
+				Path:         "/yellow",
+				URL:          "http://example.com/yellow",
+				Detectors:    map[string]struct{}{"Safety": {}},
+				Devices:      map[string]struct{}{"desktop": {}, "mobile": {}},
+				Keywords:     map[string]struct{}{"adult": {}, "VIP": {}},
+				Descriptions: map[string]struct{}{"该页面包含成人内容推广信息": {}},
+				Explanations: map[string]struct{}{"页面主文案出现成人服务、VIP 引流和联系方式": {}},
+			},
+			"/gambling": {
+				Path:         "/gambling",
+				URL:          "http://example.com/gambling",
+				Detectors:    map[string]struct{}{"Safety": {}},
+				Devices:      map[string]struct{}{"desktop": {}, "mobile": {}},
+				Keywords:     map[string]struct{}{"casino": {}, "Baccarat": {}},
+				Descriptions: map[string]struct{}{"该页面是博彩娱乐落地页": {}},
+				Explanations: map[string]struct{}{"页面出现 casino、Baccarat 等博彩关键词": {}},
+			},
+		},
+	}
+
+	card := NewNotifier("http://example.com/webhook", "53").buildAggregatedAlertMessage(alert)
+	data, err := json.Marshal(card)
+	if err != nil {
+		t.Fatalf("marshal card: %v", err)
+	}
+	body := string(data)
+
+	for _, want := range []string{
+		"**地域:** 53",
+		"**违规站点:** https://example.com",
+		"**命名空间:** ns-demo",
+		"**资源:** complik-demo-ing",
+		"**首次发现:** 2026-06-17 07:52:38",
+		"**最近发现:** 2026-06-17 07:57:38",
+		"**发现违规路径:** 2 个",
+		"**1. /gambling**",
+		"http://example.com/gambling",
+		"检测器：Safety",
+		"设备：desktop,mobile",
+		"描述：该页面是博彩娱乐落地页",
+		"命中关键词：Baccarat,casino",
+		"违规依据：页面出现 casino、Baccarat 等博彩关键词",
+		"**2. /yellow**",
+		"http://example.com/yellow",
+		"描述：该页面包含成人内容推广信息",
+		"命中关键词：VIP,adult",
+		"违规依据：页面主文案出现成人服务、VIP 引流和联系方式",
+		"后台违规记录已实时写入",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("card body missing %q: %s", want, body)
+		}
+	}
+}

--- a/complik/plugins/handle/lark/aggregator_test.go
+++ b/complik/plugins/handle/lark/aggregator_test.go
@@ -16,6 +16,7 @@
 package lark
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -24,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bearslyricattack/CompliK/complik/pkg/constants"
+	"github.com/bearslyricattack/CompliK/complik/pkg/eventbus"
 	"github.com/bearslyricattack/CompliK/complik/pkg/logger"
 	"github.com/bearslyricattack/CompliK/complik/pkg/models"
 )
@@ -289,4 +292,36 @@ func TestAggregatedCardUsesOriginalMarkdownFormat(t *testing.T) {
 			t.Fatalf("card body missing %q: %s", want, body)
 		}
 	}
+}
+
+func TestLarkPluginStopUnsubscribesDetectorTopic(t *testing.T) {
+	logger.Init()
+
+	bus := eventbus.NewEventBus(1)
+	plugin := &LarkPlugin{log: logger.GetLogger()}
+	subscription := bus.Subscribe(constants.DetectorTopic)
+	plugin.setSubscription(bus, subscription)
+
+	if err := plugin.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	select {
+	case _, ok := <-subscription:
+		if ok {
+			t.Fatal("subscription channel is open")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("subscription channel was not closed")
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Publish after Stop() panicked: %v", r)
+			}
+		}()
+
+		bus.Publish(constants.DetectorTopic, eventbus.Event{Payload: "after-stop"})
+	}()
 }

--- a/complik/plugins/handle/lark/model.go
+++ b/complik/plugins/handle/lark/model.go
@@ -14,6 +14,11 @@
 
 package lark
 
+import (
+	"sort"
+	"time"
+)
+
 type LarkMessage struct {
 	MsgType string `json:"msg_type"`
 	Card    any    `json:"card,omitempty"`
@@ -22,4 +27,111 @@ type LarkMessage struct {
 type LarkResponse struct {
 	Code int    `json:"code"`
 	Msg  string `json:"msg"`
+}
+
+type AggregatedAlert struct {
+	Region           string
+	Namespace        string
+	Host             string
+	Resource         string
+	FirstSeenAt      time.Time
+	LastSeenAt       time.Time
+	Paths            map[string]*AggregatedPath
+	OmittedPathCount int
+}
+
+type AggregatedPath struct {
+	Path         string
+	URL          string
+	Detectors    map[string]struct{}
+	Keywords     map[string]struct{}
+	Devices      map[string]struct{}
+	Descriptions map[string]struct{}
+	Explanations map[string]struct{}
+}
+
+type AggregatedPathView struct {
+	Path         string
+	URL          string
+	Detectors    []string
+	Keywords     []string
+	Devices      []string
+	Descriptions []string
+	Explanations []string
+}
+
+func (a AggregatedAlert) snapshot() AggregatedAlert {
+	out := AggregatedAlert{
+		Region:           a.Region,
+		Namespace:        a.Namespace,
+		Host:             a.Host,
+		Resource:         a.Resource,
+		FirstSeenAt:      a.FirstSeenAt,
+		LastSeenAt:       a.LastSeenAt,
+		Paths:            make(map[string]*AggregatedPath, len(a.Paths)),
+		OmittedPathCount: a.OmittedPathCount,
+	}
+
+	for key, path := range a.Paths {
+		if path == nil {
+			continue
+		}
+
+		out.Paths[key] = &AggregatedPath{
+			Path:         path.Path,
+			URL:          path.URL,
+			Detectors:    cloneSet(path.Detectors),
+			Keywords:     cloneSet(path.Keywords),
+			Devices:      cloneSet(path.Devices),
+			Descriptions: cloneSet(path.Descriptions),
+			Explanations: cloneSet(path.Explanations),
+		}
+	}
+
+	return out
+}
+
+func (a AggregatedAlert) SortedPaths() []AggregatedPathView {
+	paths := make([]AggregatedPathView, 0, len(a.Paths))
+	for _, path := range a.Paths {
+		if path == nil {
+			continue
+		}
+
+		paths = append(paths, AggregatedPathView{
+			Path:         path.Path,
+			URL:          path.URL,
+			Detectors:    sortedSetValues(path.Detectors),
+			Keywords:     sortedSetValues(path.Keywords),
+			Devices:      sortedSetValues(path.Devices),
+			Descriptions: sortedSetValues(path.Descriptions),
+			Explanations: sortedSetValues(path.Explanations),
+		})
+	}
+
+	sort.Slice(paths, func(i, j int) bool {
+		return paths[i].Path < paths[j].Path
+	})
+
+	return paths
+}
+
+func cloneSet(in map[string]struct{}) map[string]struct{} {
+	out := make(map[string]struct{}, len(in))
+	for key := range in {
+		out[key] = struct{}{}
+	}
+
+	return out
+}
+
+func sortedSetValues(values map[string]struct{}) []string {
+	items := make([]string, 0, len(values))
+	for value := range values {
+		items = append(items, value)
+	}
+
+	sort.Strings(items)
+
+	return items
 }

--- a/complik/plugins/handle/lark/notifier.go
+++ b/complik/plugins/handle/lark/notifier.go
@@ -72,6 +72,27 @@ func (f *Notifier) SendAnalysisNotification(results *models.DetectorInfo) error 
 	return f.sendMessage(message)
 }
 
+func (f *Notifier) SendAggregatedNotification(alert AggregatedAlert) error {
+	if f.WebhookURL == "" {
+		return errors.New("webhook URL not configured, skipping notification")
+	}
+
+	if strings.TrimSpace(alert.Namespace) == "" || strings.TrimSpace(alert.Host) == "" {
+		return errors.New("aggregated alert missing namespace or host")
+	}
+
+	if len(alert.Paths) == 0 {
+		return nil
+	}
+
+	message := LarkMessage{
+		MsgType: "interactive",
+		Card:    f.buildAggregatedAlertMessage(alert),
+	}
+
+	return f.sendMessage(message)
+}
+
 func (f *Notifier) buildAlertMessage(results *models.DetectorInfo) map[string]any {
 	basicInfoElements := []map[string]any{
 		{
@@ -260,6 +281,201 @@ func (f *Notifier) buildAlertMessage(results *models.DetectorInfo) map[string]an
 		},
 		"elements": elements,
 	}
+}
+
+func (f *Notifier) buildAggregatedAlertMessage(alert AggregatedAlert) map[string]any {
+	paths := alert.SortedPaths()
+	firstSeen := formatAlertTime(alert.FirstSeenAt)
+	lastSeen := formatAlertTime(alert.LastSeenAt)
+
+	elements := []map[string]any{
+		{
+			"tag": "div",
+			"text": map[string]any{
+				"content": "**地域:** " + nonEmpty(alert.Region, f.Region),
+				"tag":     "lark_md",
+			},
+		},
+		{
+			"tag": "div",
+			"text": map[string]any{
+				"content": "**违规站点:** " + alertSiteURL(alert.Host),
+				"tag":     "lark_md",
+			},
+		},
+		{
+			"tag": "div",
+			"text": map[string]any{
+				"content": "**命名空间:** " + alert.Namespace,
+				"tag":     "lark_md",
+			},
+		},
+	}
+
+	if strings.TrimSpace(alert.Resource) != "" {
+		elements = append(elements, map[string]any{
+			"tag": "div",
+			"text": map[string]any{
+				"content": "**资源:** " + alert.Resource,
+				"tag":     "lark_md",
+			},
+		})
+	}
+
+	elements = append(elements,
+		map[string]any{
+			"tag": "div",
+			"text": map[string]any{
+				"content": "**首次发现:** " + firstSeen,
+				"tag":     "lark_md",
+			},
+		},
+		map[string]any{
+			"tag": "div",
+			"text": map[string]any{
+				"content": "**最近发现:** " + lastSeen,
+				"tag":     "lark_md",
+			},
+		},
+		map[string]any{
+			"tag": "div",
+			"text": map[string]any{
+				"content": fmt.Sprintf("**发现违规路径:** %d 个", len(paths)),
+				"tag":     "lark_md",
+			},
+		},
+		map[string]any{
+			"tag": "hr",
+		},
+	)
+
+	for i, path := range paths {
+		content := formatAggregatedPath(i+1, path)
+		elements = append(elements, map[string]any{
+			"tag": "div",
+			"text": map[string]any{
+				"content": content,
+				"tag":     "lark_md",
+			},
+		})
+	}
+
+	if alert.OmittedPathCount > 0 {
+		elements = append(elements, map[string]any{
+			"tag": "div",
+			"text": map[string]any{
+				"content": fmt.Sprintf("另有 %d 条违规路径已省略，请在后台查看完整记录。", alert.OmittedPathCount),
+				"tag":     "lark_md",
+			},
+		})
+	}
+
+	elements = append(elements,
+		map[string]any{
+			"tag": "hr",
+		},
+		map[string]any{
+			"tag": "div",
+			"text": map[string]any{
+				"content": "**请及时处理违规内容。后台违规记录已实时写入，可用于审计追溯。**",
+				"tag":     "lark_md",
+			},
+		},
+	)
+
+	return map[string]any{
+		"config": map[string]any{
+			"wide_screen_mode": true,
+		},
+		"header": map[string]any{
+			"template": "red",
+			"title": map[string]any{
+				"content": "网站内容违规聚合告警",
+				"tag":     "plain_text",
+			},
+		},
+		"elements": elements,
+	}
+}
+
+func formatAggregatedPath(index int, path AggregatedPathView) string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "**%d. %s**\n", index, nonEmpty(path.Path, "/"))
+	if strings.TrimSpace(path.URL) != "" {
+		builder.WriteString(path.URL)
+		builder.WriteString("\n")
+	}
+	if len(path.Detectors) > 0 {
+		builder.WriteString("检测器：")
+		builder.WriteString(strings.Join(path.Detectors, ","))
+		builder.WriteString("\n")
+	}
+	if len(path.Devices) > 0 {
+		builder.WriteString("设备：")
+		builder.WriteString(strings.Join(path.Devices, ","))
+		builder.WriteString("\n")
+	}
+	if len(path.Descriptions) > 0 {
+		builder.WriteString("描述：")
+		builder.WriteString(strings.Join(path.Descriptions, "\n"))
+		builder.WriteString("\n")
+	}
+	if len(path.Keywords) > 0 {
+		builder.WriteString("命中关键词：")
+		builder.WriteString(strings.Join(path.Keywords, ","))
+		builder.WriteString("\n")
+	}
+	if len(path.Explanations) > 0 {
+		builder.WriteString("违规依据：")
+		builder.WriteString(strings.Join(path.Explanations, "\n"))
+		builder.WriteString("\n")
+	}
+
+	return strings.TrimSpace(builder.String())
+}
+
+func formatCodeValues(values []string) string {
+	var builder strings.Builder
+	for i, value := range values {
+		if i > 0 {
+			builder.WriteString(", ")
+		}
+
+		fmt.Fprintf(&builder, "`%s`", strings.TrimSpace(value))
+	}
+
+	return builder.String()
+}
+
+func formatAlertTime(value time.Time) string {
+	if value.IsZero() {
+		return time.Now().Format(time.DateTime)
+	}
+
+	return value.Local().Format(time.DateTime)
+}
+
+func alertSiteURL(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(host, "http://") || strings.HasPrefix(host, "https://") {
+		return host
+	}
+
+	return "https://" + host
+}
+
+func nonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+
+	return ""
 }
 
 func (f *Notifier) sendMessage(message LarkMessage) error {

--- a/complik/plugins/handle/lark/notifier.go
+++ b/complik/plugins/handle/lark/notifier.go
@@ -434,19 +434,6 @@ func formatAggregatedPath(index int, path AggregatedPathView) string {
 	return strings.TrimSpace(builder.String())
 }
 
-func formatCodeValues(values []string) string {
-	var builder strings.Builder
-	for i, value := range values {
-		if i > 0 {
-			builder.WriteString(", ")
-		}
-
-		fmt.Fprintf(&builder, "`%s`", strings.TrimSpace(value))
-	}
-
-	return builder.String()
-}
-
 func formatAlertTime(value time.Time) string {
 	if value.IsZero() {
 		return time.Now().Format(time.DateTime)

--- a/complik/plugins/handle/lark/plugin.go
+++ b/complik/plugins/handle/lark/plugin.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bearslyricattack/CompliK/complik/pkg/constants"
@@ -47,10 +48,13 @@ func init() {
 }
 
 type LarkPlugin struct {
-	log        logger.Logger
-	notifier   *Notifier
-	aggregator *NotificationAggregator
-	larkConfig LarkConfig
+	log                  logger.Logger
+	notifier             *Notifier
+	aggregator           *NotificationAggregator
+	larkConfig           LarkConfig
+	subscriptionMu       sync.Mutex
+	subscriptionEventBus *eventbus.EventBus
+	subscription         eventbus.EventChan
 }
 
 func (p *LarkPlugin) Name() string {
@@ -200,6 +204,7 @@ func (p *LarkPlugin) Start(
 		return err
 	}
 
+	p.stopAggregator()
 	p.notifier = NewNotifier(p.larkConfig.Webhook, p.larkConfig.Region)
 	p.aggregator = NewNotificationAggregator(
 		time.Duration(p.larkConfig.AggregationWindowSecond)*time.Second,
@@ -209,8 +214,12 @@ func (p *LarkPlugin) Start(
 		p.log,
 	)
 
+	p.unsubscribeDetectorTopic(nil)
+
 	subscribe := eventBus.Subscribe(constants.DetectorTopic)
-	go func() {
+	p.setSubscription(eventBus, subscribe)
+	go func(subscription eventbus.EventChan) {
+		defer p.unsubscribeDetectorTopic(subscription)
 		defer func() {
 			if r := recover(); r != nil {
 				p.log.Error("Plugin goroutine panic", logger.Fields{
@@ -221,7 +230,7 @@ func (p *LarkPlugin) Start(
 
 		for {
 			select {
-			case event, ok := <-subscribe:
+			case event, ok := <-subscription:
 				if !ok {
 					p.log.Info("Event subscription channel closed")
 					return
@@ -244,15 +253,54 @@ func (p *LarkPlugin) Start(
 				return
 			}
 		}
-	}()
+	}(subscribe)
 
 	return nil
 }
 
 func (p *LarkPlugin) Stop(ctx context.Context) error {
-	if p.aggregator != nil {
-		p.aggregator.Stop()
-	}
+	p.unsubscribeDetectorTopic(nil)
+	p.stopAggregator()
 
 	return nil
+}
+
+func (p *LarkPlugin) stopAggregator() {
+	if p.aggregator == nil {
+		return
+	}
+
+	p.aggregator.Stop()
+	p.aggregator = nil
+}
+
+func (p *LarkPlugin) setSubscription(
+	eventBus *eventbus.EventBus,
+	subscription eventbus.EventChan,
+) {
+	p.subscriptionMu.Lock()
+	defer p.subscriptionMu.Unlock()
+
+	p.subscriptionEventBus = eventBus
+	p.subscription = subscription
+}
+
+func (p *LarkPlugin) unsubscribeDetectorTopic(subscription eventbus.EventChan) {
+	p.subscriptionMu.Lock()
+	if p.subscriptionEventBus == nil || p.subscription == nil {
+		p.subscriptionMu.Unlock()
+		return
+	}
+	if subscription != nil && p.subscription != subscription {
+		p.subscriptionMu.Unlock()
+		return
+	}
+
+	eventBus := p.subscriptionEventBus
+	activeSubscription := p.subscription
+	p.subscriptionEventBus = nil
+	p.subscription = nil
+	p.subscriptionMu.Unlock()
+
+	eventBus.Unsubscribe(constants.DetectorTopic, activeSubscription)
 }

--- a/complik/plugins/handle/lark/plugin.go
+++ b/complik/plugins/handle/lark/plugin.go
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 // Package lark implements a notification plugin for Lark (Feishu) messaging platform.
+//
+//nolint:wsl_v5 // Plugin config loading keeps related override branches compact.
 package lark
 
 import (

--- a/complik/plugins/handle/lark/plugin.go
+++ b/complik/plugins/handle/lark/plugin.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/bearslyricattack/CompliK/complik/pkg/constants"
 	"github.com/bearslyricattack/CompliK/complik/pkg/eventbus"
@@ -46,6 +47,7 @@ func init() {
 type LarkPlugin struct {
 	log        logger.Logger
 	notifier   *Notifier
+	aggregator *NotificationAggregator
 	larkConfig LarkConfig
 }
 
@@ -58,19 +60,25 @@ func (p *LarkPlugin) Type() string {
 }
 
 type LarkConfig struct {
-	Region                 string `json:"region"`
-	Webhook                string `json:"webhook"`
-	AdminBaseURL           string `json:"adminBaseURL"`
-	AdminTimeoutSecond     int    `json:"adminTimeoutSecond"`
-	AdminBasicAuthUsername string `json:"adminBasicAuthUsername"`
-	AdminBasicAuthPassword string `json:"adminBasicAuthPassword"`
+	Region                  string `json:"region"`
+	Webhook                 string `json:"webhook"`
+	AggregationWindowSecond int    `json:"aggregationWindowSecond"`
+	MaxAggregationBuckets   int    `json:"maxAggregationBuckets"`
+	MaxPathsPerBucket       int    `json:"maxPathsPerBucket"`
+	AdminBaseURL            string `json:"adminBaseURL"`
+	AdminTimeoutSecond      int    `json:"adminTimeoutSecond"`
+	AdminBasicAuthUsername  string `json:"adminBasicAuthUsername"`
+	AdminBasicAuthPassword  string `json:"adminBasicAuthPassword"`
 }
 
 func (p *LarkPlugin) getDefaultConfig() LarkConfig {
 	return LarkConfig{
-		Region:             "UNKNOWN",
-		AdminBaseURL:       config.DefaultAdminBaseURL,
-		AdminTimeoutSecond: config.DefaultAdminTimeoutSecond,
+		Region:                  "UNKNOWN",
+		AggregationWindowSecond: int(defaultAggregationWindow / time.Second),
+		MaxAggregationBuckets:   defaultMaxAggregationBuckets,
+		MaxPathsPerBucket:       defaultMaxPathsPerBucket,
+		AdminBaseURL:            config.DefaultAdminBaseURL,
+		AdminTimeoutSecond:      config.DefaultAdminTimeoutSecond,
 	}
 }
 
@@ -94,6 +102,15 @@ func (p *LarkPlugin) loadConfig(ctx context.Context, setting string) error {
 	p.larkConfig.Webhook = configFromJSON.Webhook
 	if configFromJSON.Region != "" {
 		p.larkConfig.Region = configFromJSON.Region
+	}
+	if configFromJSON.AggregationWindowSecond > 0 {
+		p.larkConfig.AggregationWindowSecond = configFromJSON.AggregationWindowSecond
+	}
+	if configFromJSON.MaxAggregationBuckets > 0 {
+		p.larkConfig.MaxAggregationBuckets = configFromJSON.MaxAggregationBuckets
+	}
+	if configFromJSON.MaxPathsPerBucket > 0 {
+		p.larkConfig.MaxPathsPerBucket = configFromJSON.MaxPathsPerBucket
 	}
 
 	if strings.TrimSpace(configFromJSON.AdminBaseURL) != "" {
@@ -158,6 +175,15 @@ func (p *LarkPlugin) applyNotificationsRuntimeConfig(ctx context.Context) error 
 	}
 
 	p.larkConfig.Webhook = webhook
+	if runtimeCfg.AggregationWindowSecond > 0 {
+		p.larkConfig.AggregationWindowSecond = runtimeCfg.AggregationWindowSecond
+	}
+	if runtimeCfg.MaxAggregationBuckets > 0 {
+		p.larkConfig.MaxAggregationBuckets = runtimeCfg.MaxAggregationBuckets
+	}
+	if runtimeCfg.MaxPathsPerBucket > 0 {
+		p.larkConfig.MaxPathsPerBucket = runtimeCfg.MaxPathsPerBucket
+	}
 
 	return nil
 }
@@ -173,6 +199,13 @@ func (p *LarkPlugin) Start(
 	}
 
 	p.notifier = NewNotifier(p.larkConfig.Webhook, p.larkConfig.Region)
+	p.aggregator = NewNotificationAggregator(
+		time.Duration(p.larkConfig.AggregationWindowSecond)*time.Second,
+		p.larkConfig.MaxAggregationBuckets,
+		p.larkConfig.MaxPathsPerBucket,
+		p.notifier,
+		p.log,
+	)
 
 	subscribe := eventBus.Subscribe(constants.DetectorTopic)
 	go func() {
@@ -203,13 +236,7 @@ func (p *LarkPlugin) Start(
 				}
 
 				result.Region = p.larkConfig.Region
-
-				err := p.notifier.SendAnalysisNotification(result)
-				if err != nil {
-					p.log.Error("Failed to send notification", logger.Fields{
-						"error": err.Error(),
-					})
-				}
+				p.aggregator.Add(result)
 			case <-ctx.Done():
 				p.log.Info("Plugin received stop signal")
 				return
@@ -221,5 +248,9 @@ func (p *LarkPlugin) Start(
 }
 
 func (p *LarkPlugin) Stop(ctx context.Context) error {
+	if p.aggregator != nil {
+		p.aggregator.Stop()
+	}
+
 	return nil
 }


### PR DESCRIPTION
## Changes

- Add VLogPathDiscovery to discover real sub-paths from Higress/VLog access logs
- Aggregate Lark violation alerts by namespace + host
- Include per-path description, matched keywords, and violation evidence in alerts
- Add stability guards for VLog scans and Lark aggregation
- Fix EventBus unsubscribe locking behavior

## Validation

- go test ./...
- golangci-lint run --color=never